### PR TITLE
Add exclusion to fix issue #22

### DIFF
--- a/sirerrors.c
+++ b/sirerrors.c
@@ -103,7 +103,7 @@ void __sir_handleerr(int code, const char* func, const char* file, uint32_t line
         char* tmp = strerror(code);
         _sir_strncpy(message, SIR_MAXERROR, tmp, strnlen(tmp, SIR_MAXERROR));
 #endif
-	/* cppcheck-suppress knownConditionTrueFalse */
+        /* cppcheck-suppress knownConditionTrueFalse */
         if (0 == finderr && _sir_validstrnofail(message)) {
             __sir_setoserror(code, message, func, file, line);
         } else {

--- a/sirerrors.c
+++ b/sirerrors.c
@@ -103,6 +103,7 @@ void __sir_handleerr(int code, const char* func, const char* file, uint32_t line
         char* tmp = strerror(code);
         _sir_strncpy(message, SIR_MAXERROR, tmp, strnlen(tmp, SIR_MAXERROR));
 #endif
+	/* cppcheck-suppress knownConditionTrueFalse */
         if (0 == finderr && _sir_validstrnofail(message)) {
             __sir_setoserror(code, message, func, file, line);
         } else {


### PR DESCRIPTION
It's always true if it takes the path without XSI_STRERROR_R and XSI_STRERROR_R_ERRNO, and without STRERROR_S, it's simply explicitly set and then checked, not worth refactoring extensively just to avoid the warning.

Closes #22 