### PR TITLE
Use intptr_t for sir_fopen; closes #19

### DIFF
--- a/sirfilecache.c
+++ b/sirfilecache.c
@@ -124,7 +124,7 @@ bool _sirfile_open(sirfile* sf) {
         return false;
 
     FILE* f  = NULL;
-    int open = _sir_fopen(&f, sf->path, SIR_FOPENMODE);
+    intptr_t open = _sir_fopen(&f, sf->path, SIR_FOPENMODE);
     if (0 != open || !f)
         return false;
 

--- a/sirhelpers.c
+++ b/sirhelpers.c
@@ -208,7 +208,7 @@ int _sir_strncat(char* restrict dest, size_t destsz, const char* restrict src, s
  * Wrapper for fopen/fopen_s. Determines which one to use
  * based on preprocessor macros.
  */
-int _sir_fopen(FILE* restrict* restrict streamptr, const char* restrict filename,
+intptr_t _sir_fopen(FILE* restrict* restrict streamptr, const char* restrict filename,
     const char* restrict mode) {
     if (_sir_notnull(streamptr) && _sir_validstr(filename) && _sir_validstr(mode)) {
 #if defined(__HAVE_STDC_SECURE_OR_EXT1__)

--- a/sirhelpers.h
+++ b/sirhelpers.h
@@ -235,7 +235,7 @@ int _sir_strncat(char* restrict dest, size_t destsz,
  * Wrapper for fopen/fopen_s. Determines which one to use
  * based on preprocessor macros.
  */
-int _sir_fopen(FILE* restrict* restrict streamptr, const char* restrict filename,
+intptr_t _sir_fopen(FILE* restrict* restrict streamptr, const char* restrict filename,
     const char* restrict mode);
 
 /**


### PR DESCRIPTION
Should be standards conforming on both Windows and UNIX; Closes #19