### PR TITLE
Add support for Solaris and illumos

### DIFF
--- a/sirfilesystem.c
+++ b/sirfilesystem.c
@@ -61,6 +61,8 @@ bool _sir_pathgetstat(const char* restrict path, struct stat* restrict st, sir_r
         int open_flags = O_PATH | O_DIRECTORY;
 # elif defined(__BSD__)
         int open_flags = O_EXEC | O_DIRECTORY;
+# elif defined(__SOLARIS__)
+        int open_flags = O_DIRECTORY;
 # endif
 
         int fd = open(base_path, open_flags);
@@ -159,9 +161,15 @@ char* _sir_getappfilename(void) {
             grow = false;
         }
 
+#if defined(__linux__)
+# define PROC_SELF "/proc/self/exe"
+#elif defined(__SOLARIS__)
+# define PROC_SELF "/proc/self/path/a.out"
+#endif
+
 #if !defined(__WIN__)
-# if defined(__linux__)
-        ssize_t read = readlink("/proc/self/exe", buffer, size - 1);
+# if defined(__linux__) || defined(__SOLARIS__)
+        ssize_t read = readlink(PROC_SELF, buffer, size - 1);
         if (-1 != read && read < (ssize_t)size - 1) {
             resolved = true;
             break;

--- a/sirinternal.c
+++ b/sirinternal.c
@@ -1091,6 +1091,8 @@ pid_t _sir_gettid(void) {
     if (0 != gettid)
         _sir_handleerr(gettid);
     tid = (pid_t)tid64;
+#elif defined(__SOLARIS__)
+    tid = (pid_t)pthread_self();
 #elif defined(__BSD__)
     tid = (pid_t)pthread_getthreadid_np();
 #elif defined(_DEFAULT_SOURCE)

--- a/sirplatform.h
+++ b/sirplatform.h
@@ -74,6 +74,13 @@
 #     undef USE_PTHREAD_GETNAME_NP
 #    endif
 #   endif
+#   if (defined(__sun) || defined(__sun__)) && (defined(__SVR4) || defined(__svr4__))
+#    define __SOLARIS__
+#    define USE_PTHREAD_GETNAME_NP
+#    if !defined(__EXTENSIONS__)
+#     define __EXTENSIONS__
+#    endif
+#   endif
 #   if !defined(_POSIX_C_SOURCE)
 #    define _POSIX_C_SOURCE 200809L
 #   endif

--- a/sirplatform.h
+++ b/sirplatform.h
@@ -74,9 +74,12 @@
 #     undef USE_PTHREAD_GETNAME_NP
 #    endif
 #   endif
-#   if (defined(__sun) || defined(__sun__)) && (defined(__SVR4) || defined(__svr4__))
+#   if defined(__illumos__) || ((defined(__sun) || defined(__sun__)) && (defined(__SVR4) || defined(__svr4__)))
 #    define __SOLARIS__
 #    define USE_PTHREAD_GETNAME_NP
+#    if !defined(_ATFILE_SOURCE)
+#     define _ATFILE_SOURCE 1
+#    endif
 #    if !defined(__EXTENSIONS__)
 #     define __EXTENSIONS__
 #    endif
@@ -153,6 +156,9 @@
 
 # if !defined(__WIN__)
 #  include <pthread.h>
+# if defined(__illumos__)
+#  include <sys/fcntl.h>
+# endif
 #  include <fcntl.h>
 #  include <unistd.h>
 #  include <sys/syscall.h>


### PR DESCRIPTION
* Tested on OpenIndiana 2023.05 with GCC 7.5.0, GCC 10.4.0, GCC 11.3.0, and Clang 15.0.7.
* Tested on Solaris 11.4 SRU 42 with GCC 11.2.0 and Clang 11.0.0.