### PR TITLE
Add support for DragonFly BSD and NetBSD

### DIFF
--- a/sirfilesystem.c
+++ b/sirfilesystem.c
@@ -59,9 +59,9 @@ bool _sir_pathgetstat(const char* restrict path, struct stat* restrict st, sir_r
         int open_flags = O_SEARCH;
 # elif defined(__linux__)
         int open_flags = O_PATH | O_DIRECTORY;
-# elif defined(__BSD__)
+# elif defined(__FreeBSD__)
         int open_flags = O_EXEC | O_DIRECTORY;
-# elif defined(__SOLARIS__)
+# elif defined(__SOLARIS__) || defined(__NetBSD__)
         int open_flags = O_DIRECTORY;
 # endif
 
@@ -163,12 +163,14 @@ char* _sir_getappfilename(void) {
 
 #if defined(__linux__)
 # define PROC_SELF "/proc/self/exe"
+#elif defined(__NetBSD__)
+# define PROC_SELF "/proc/curproc/exe"
 #elif defined(__SOLARIS__)
 # define PROC_SELF "/proc/self/path/a.out"
 #endif
 
 #if !defined(__WIN__)
-# if defined(__linux__) || defined(__SOLARIS__)
+# if defined(__linux__) || defined(__NetBSD__) || defined(__SOLARIS__)
         ssize_t read = readlink(PROC_SELF, buffer, size - 1);
         if (-1 != read && read < (ssize_t)size - 1) {
             resolved = true;

--- a/sirfilesystem.c
+++ b/sirfilesystem.c
@@ -61,7 +61,7 @@ bool _sir_pathgetstat(const char* restrict path, struct stat* restrict st, sir_r
         int open_flags = O_PATH | O_DIRECTORY;
 # elif defined(__FreeBSD__)
         int open_flags = O_EXEC | O_DIRECTORY;
-# elif defined(__SOLARIS__) || defined(__NetBSD__)
+# elif defined(__SOLARIS__) || defined(__NetBSD__) || defined(__DragonFly__)
         int open_flags = O_DIRECTORY;
 # endif
 
@@ -165,12 +165,14 @@ char* _sir_getappfilename(void) {
 # define PROC_SELF "/proc/self/exe"
 #elif defined(__NetBSD__)
 # define PROC_SELF "/proc/curproc/exe"
+#elif defined(__DragonFly__)
+# define PROC_SELF "/proc/curproc/file"
 #elif defined(__SOLARIS__)
 # define PROC_SELF "/proc/self/path/a.out"
 #endif
 
 #if !defined(__WIN__)
-# if defined(__linux__) || defined(__NetBSD__) || defined(__SOLARIS__)
+# if defined(__linux__) || defined(__NetBSD__) || defined(__SOLARIS__) || defined(__DragonFly__)
         ssize_t read = readlink(PROC_SELF, buffer, size - 1);
         if (-1 != read && read < (ssize_t)size - 1) {
             resolved = true;

--- a/sirinternal.c
+++ b/sirinternal.c
@@ -1091,10 +1091,10 @@ pid_t _sir_gettid(void) {
     if (0 != gettid)
         _sir_handleerr(gettid);
     tid = (pid_t)tid64;
-#elif defined(__SOLARIS__)
-    tid = (pid_t)pthread_self();
-#elif defined(__BSD__)
+#elif defined(__BSD__) && !defined(__NetBSD__)
     tid = (pid_t)pthread_getthreadid_np();
+#elif defined(__SOLARIS__) || defined(__NetBSD__)
+    tid = (pid_t)pthread_self();
 #elif defined(_DEFAULT_SOURCE)
     tid = syscall(SYS_gettid);
 #elif defined(__WIN__)

--- a/sirinternal.c
+++ b/sirinternal.c
@@ -1091,9 +1091,9 @@ pid_t _sir_gettid(void) {
     if (0 != gettid)
         _sir_handleerr(gettid);
     tid = (pid_t)tid64;
-#elif defined(__BSD__) && !defined(__NetBSD__)
+#elif (defined(__BSD__) && !defined(__NetBSD__)) || defined(__DragonFly_getthreadid__)
     tid = (pid_t)pthread_getthreadid_np();
-#elif defined(__SOLARIS__) || defined(__NetBSD__)
+#elif defined(__SOLARIS__) || defined(__NetBSD__) || defined(__DragonFly__)
     tid = (pid_t)pthread_self();
 #elif defined(_DEFAULT_SOURCE)
     tid = syscall(SYS_gettid);

--- a/sirplatform.h
+++ b/sirplatform.h
@@ -43,6 +43,11 @@
 #    endif
 #   endif
 #  endif
+#  if defined(__DragonFly__) // Clang on DragonFly is missing stdatomic.h
+#   if defined(__clang__) && defined(__clang_version__)
+#    undef __HAVE_ATOMIC_H__
+#   endif
+#  endif
 #  if defined(__STDC_WANT_LIB_EXT1__)
 #   undef __STDC_WANT_LIB_EXT1__
 #  endif
@@ -55,7 +60,7 @@
 #    define _NETBSD_SOURCE 1
 #   endif
 #   define __BSD__
-#  elif defined(__FreeBSD__)
+#  elif defined(__FreeBSD__) || defined(__DragonFly__)
 #   include <sys/param.h>
 #   define __BSD__
 #   define _BSD_SOURCE
@@ -66,6 +71,11 @@
 #    define __FreeBSD_PTHREAD_NP_12_2__
 #   elif __FreeBSD_version >= 1103500
 #    define __FreeBSD_PTHREAD_NP_11_3__
+#   elif __DragonFly_version >= 400907
+#    define __DragonFly_getthreadid__
+#   endif
+#   if defined(__DragonFly__)
+#    define USE_PTHREAD_GETNAME_NP
 #   endif
 #  else
 #   if defined(__linux__)

--- a/sirplatform.h
+++ b/sirplatform.h
@@ -60,6 +60,7 @@
 #    define _NETBSD_SOURCE 1
 #   endif
 #   define __BSD__
+#   define USE_PTHREAD_GETNAME_NP
 #  elif defined(__FreeBSD__) || defined(__DragonFly__)
 #   include <sys/param.h>
 #   define __BSD__

--- a/sirplatform.h
+++ b/sirplatform.h
@@ -171,9 +171,9 @@
 
 # if !defined(__WIN__)
 #  include <pthread.h>
-# if defined(__illumos__)
-#  include <sys/fcntl.h>
-# endif
+#  if defined(__illumos__)
+#   include <sys/fcntl.h>
+#  endif
 #  include <fcntl.h>
 #  include <unistd.h>
 #  include <sys/syscall.h>

--- a/sirplatform.h
+++ b/sirplatform.h
@@ -50,6 +50,11 @@
 #  if defined(__APPLE__) && defined(__MACH__)
 #   define __MACOS__
 #   define _DARWIN_C_SOURCE
+#  elif defined(__NetBSD__)
+#   if !defined(_NETBSD_SOURCE)
+#    define _NETBSD_SOURCE 1
+#   endif
+#   define __BSD__
 #  elif defined(__FreeBSD__)
 #   include <sys/param.h>
 #   define __BSD__
@@ -174,7 +179,9 @@
 #   include <syslog.h>
 #  endif
 #  if defined(__BSD__)
-#   include <pthread_np.h>
+#   if !defined(__NetBSD__)
+#    include <pthread_np.h>
+#   endif
 #   include <sys/sysctl.h>
 #  elif defined(__linux__)
 #   if defined(__GLIBC__)


### PR DESCRIPTION
* Add support for DragonFly BSD.
  * Tested on DragonFly BSD 6.4.0-RELEASE and 6.5-DEVELOPMENT using GCC 8.3.0, GCC 12.2.0, GCC 13.0.0, Clang 14.0.6, Clang 13.0.1, Clang 12.0.1, Clang 11.0.1, and Clang 10.0.1.
[]()
* Add support for NetBSD.
  * Tested on NetBSD 9.3-STABLE (ARM64 and AMD64) with Clang 15.0.7, GCC 7.5.0, GCC 12.2.0, and GCC 13.1.0.

---

* The DragonFly BSD support includes a workaround for Clang missing `<stdatomic.h>`.  This affects all Clang packages on DragonFly BSD.  If a future Clang package corrects this issue, the Clang version number may be checked to disable the workaround.