### PR TITLE
Flawfinder

### DIFF
--- a/sirfilesystem.c
+++ b/sirfilesystem.c
@@ -185,7 +185,8 @@ char* _sir_getappfilename(void) {
 #endif
 
 #if !defined(__WIN__)
-# if defined(__linux__) || defined(__NetBSD__) || defined(__SOLARIS__) || defined(__DragonFly__) || defined(__CYGWIN__)
+# if defined(__linux__) || defined(__NetBSD__) || defined(__SOLARIS__) || \
+     defined(__DragonFly__) || defined(__CYGWIN__)
         ssize_t read = readlink(PROC_SELF, buffer, size - 1);
         if (-1 != read && read < (ssize_t)size - 1) {
             resolved = true;

--- a/sirhelpers.c
+++ b/sirhelpers.c
@@ -195,7 +195,7 @@ int _sir_strncpy(char* restrict dest, size_t destsz, const char* restrict src, s
             return -1;
         }
         return 0;
-#elif defined(__MACOS__) || defined(__FreeBSD__)
+#elif defined(__MACOS__) || defined(__BSD__)
         _SIR_UNUSED(count);
         size_t cpy = strlcpy(dest, src, destsz);
         SIR_ASSERT(cpy < destsz);
@@ -220,7 +220,7 @@ int _sir_strncat(char* restrict dest, size_t destsz, const char* restrict src, s
             return -1;
         }
         return 0;
-#elif defined(__MACOS__) || defined(__FreeBSD__)
+#elif defined(__MACOS__) || defined(__BSD__)
         _SIR_UNUSED(count);
         size_t cat = strlcat(dest, src, destsz);
         SIR_ASSERT(cat < destsz);

--- a/sirhelpers.c
+++ b/sirhelpers.c
@@ -194,7 +194,12 @@ int _sir_strncpy(char* restrict dest, size_t destsz, const char* restrict src, s
             _sir_handleerr(ret);
             return -1;
         }
-
+        return 0;
+#elif defined(__MACOS__) || defined(__FreeBSD__)
+        _SIR_UNUSED(count);
+        size_t cpy = strlcpy(dest, src, destsz);
+        SIR_ASSERT(cpy < destsz);
+        _SIR_UNUSED(cpy);
         return 0;
 #else
         _SIR_UNUSED(destsz);
@@ -206,10 +211,6 @@ int _sir_strncpy(char* restrict dest, size_t destsz, const char* restrict src, s
     return -1;
 }
 
-/**
- * Wrapper for strncat/strncat_s. Determines which one to use
- * based on preprocessor macros.
- */
 int _sir_strncat(char* restrict dest, size_t destsz, const char* restrict src, size_t count) {
     if (_sir_validptr(dest) && _sir_validstr(src)) {
 #if defined(__HAVE_STDC_SECURE_OR_EXT1__)
@@ -218,7 +219,12 @@ int _sir_strncat(char* restrict dest, size_t destsz, const char* restrict src, s
             _sir_handleerr(ret);
             return -1;
         }
-
+        return 0;
+#elif defined(__MACOS__) || defined(__FreeBSD__)
+        _SIR_UNUSED(count);
+        size_t cat = strlcat(dest, src, destsz);
+        SIR_ASSERT(cat < destsz);
+        _SIR_UNUSED(cat);
         return 0;
 #else
         _SIR_UNUSED(destsz);
@@ -230,20 +236,15 @@ int _sir_strncat(char* restrict dest, size_t destsz, const char* restrict src, s
     return -1;
 }
 
-/**
- * Wrapper for fopen/fopen_s. Determines which one to use
- * based on preprocessor macros.
- */
 int _sir_fopen(FILE* restrict* restrict streamptr, const char* restrict filename,
     const char* restrict mode) {
-    if (_sir_validptrptr((void**)streamptr) && _sir_validstr(filename) && _sir_validstr(mode)) {
+    if (_sir_validptrptr(streamptr) && _sir_validstr(filename) && _sir_validstr(mode)) {
 #if defined(__HAVE_STDC_SECURE_OR_EXT1__)
         int ret = fopen_s(streamptr, filename, mode);
         if (0 != ret) {
             _sir_handleerr(ret);
             return -1;
         }
-
         return 0;
 #else
         *streamptr = fopen(filename, mode);
@@ -251,7 +252,6 @@ int _sir_fopen(FILE* restrict* restrict streamptr, const char* restrict filename
             _sir_handleerr(errno);
             return -1;
         }
-
         return 0;
 #endif
     }

--- a/sirhelpers.h
+++ b/sirhelpers.h
@@ -211,14 +211,14 @@ bool _sir_strsame(const char* lhs, const char* rhs, size_t count) {
 }
 
 /**
- * Wrapper for strncpy/strncpy_s. Determines which one to use
+ * Wrapper for str[n,l]cpy/strncpy_s. Determines which one to use
  * based on preprocessor macros.
  */
 int _sir_strncpy(char* restrict dest, size_t destsz,
     const char* restrict src, size_t count);
 
 /**
- * Wrapper for strncat/strncat_s. Determines which one to use
+ * Wrapper for str[n,l]cat/strncat_s. Determines which one to use
  * based on preprocessor macros.
  */
 int _sir_strncat(char* restrict dest, size_t destsz,

--- a/sirinternal.c
+++ b/sirinternal.c
@@ -422,7 +422,6 @@ bool _sir_mapmutexid(sir_mutex_id mid, sir_mutex** m, void** section) {
             break;
     }
 
-    SIR_ASSERT(m);
     *m = tmpm;
 
     if (section)

--- a/sirplatform.h
+++ b/sirplatform.h
@@ -71,6 +71,7 @@
 #   if !defined(_DEFAULT_SOURCE)
 #    define _DEFAULT_SOURCE
 #   endif
+#   include <sys/param.h>
 #   if __FreeBSD_version >= 1202500
 #    define __FreeBSD_PTHREAD_NP_12_2__
 #   elif __FreeBSD_version >= 1103500
@@ -209,9 +210,6 @@ int pthread_getname_np(pthread_t thread, char* buffer, size_t length);
 #   include <syslog.h>
 #  endif
 #  if defined(__BSD__)
-#   if defined(__FreeBSD__) || defined(__DragonFly__)
-#    include <sys/param.h>
-#   endif
 #   if !defined(__NetBSD__)
 #    include <pthread_np.h>
 #   endif

--- a/sirplatform.h
+++ b/sirplatform.h
@@ -43,7 +43,7 @@
 #    endif
 #   endif
 #  endif
-#  if defined(__DragonFly__) // Clang on DragonFly is missing stdatomic.h
+#  if defined(__DragonFly__)
 #   if defined(__clang__) && defined(__clang_version__)
 #    undef __HAVE_ATOMIC_H__
 #   endif
@@ -52,17 +52,20 @@
 #   undef __STDC_WANT_LIB_EXT1__
 #  endif
 #  define __STDC_WANT_LIB_EXT1__ 1
+#  if defined(__STDC_WANT_LIB_EXT2__)
+#   undef __STDC_WANT_LIB_EXT2__
+#  endif
+#  define __STDC_WANT_LIB_EXT2__ 1
 #  if defined(__APPLE__) && defined(__MACH__)
 #   define __MACOS__
 #   define _DARWIN_C_SOURCE
 #  elif defined(__NetBSD__)
+#   define __BSD__
 #   if !defined(_NETBSD_SOURCE)
 #    define _NETBSD_SOURCE 1
 #   endif
-#   define __BSD__
 #   define USE_PTHREAD_GETNAME_NP
 #  elif defined(__FreeBSD__) || defined(__DragonFly__)
-#   include <sys/param.h>
 #   define __BSD__
 #   define _BSD_SOURCE
 #   if !defined(_DEFAULT_SOURCE)
@@ -86,10 +89,9 @@
 #    if !defined(_GNU_SOURCE)
 #     define _GNU_SOURCE
 #    endif
-#    include <OS.h>
-#    include <FindDirectory.h>
-#    if defined(__clang__) && !defined(_GNU_PTHREAD_H_) // Workaround a Clang on Haiku bug
-extern int pthread_getname_np(pthread_t thread, char* buffer, size_t length);
+#    if defined(__clang__) && !defined(_GNU_PTHREAD_H_)
+extern /* Workaround a Clang on Haiku bug. */
+int pthread_getname_np(pthread_t thread, char* buffer, size_t length);
 #    endif
 #    define USE_PTHREAD_GETNAME_NP
 #   endif
@@ -104,7 +106,8 @@ extern int pthread_getname_np(pthread_t thread, char* buffer, size_t length);
 #     undef USE_PTHREAD_GETNAME_NP
 #    endif
 #   endif
-#   if defined(__illumos__) || ((defined(__sun) || defined(__sun__)) && (defined(__SVR4) || defined(__svr4__)))
+#   if defined(__illumos__) || ((defined(__sun) || defined(__sun__)) && \
+              (defined(__SVR4) || defined(__svr4__)))
 #    define __SOLARIS__
 #    define USE_PTHREAD_GETNAME_NP
 #    if !defined(_ATFILE_SOURCE)
@@ -125,14 +128,14 @@ extern int pthread_getname_np(pthread_t thread, char* buffer, size_t length);
 #   endif
 #  endif
 # else /* _WIN32 */
+#  define __WIN__
 #  define SIR_NO_SYSTEM_LOGGERS
 #  undef __HAVE_ATOMIC_H__
 #  define __WANT_STDC_SECURE_LIB__ 1
-#  define _CRT_RAND_S
 #  define WIN32_LEAN_AND_MEAN
-#  define WINVER 0x0A00 /** Windows 10 SDK */
+#  define WINVER       0x0A00 /** Windows 10 SDK */
 #  define _WIN32_WINNT 0x0A00
-#  define __WIN__
+#  define _CRT_RAND_S
 #  include <windows.h>
 #  include <io.h>
 #  include <synchapi.h>
@@ -206,6 +209,9 @@ extern int pthread_getname_np(pthread_t thread, char* buffer, size_t length);
 #   include <syslog.h>
 #  endif
 #  if defined(__BSD__)
+#   if defined(__FreeBSD__) || defined(__DragonFly__)
+#    include <sys/param.h>
+#   endif
 #   if !defined(__NetBSD__)
 #    include <pthread_np.h>
 #   endif
@@ -214,6 +220,9 @@ extern int pthread_getname_np(pthread_t thread, char* buffer, size_t length);
 #   if defined(__GLIBC__)
 #    include <linux/limits.h>
 #   endif
+#  elif defined(__HAIKU__)
+#   include <OS.h>
+#   include <FindDirectory.h>
 #  elif defined(__MACOS__)
 #   include <mach-o/dyld.h>
 #   include <sys/_types/_timespec.h>
@@ -295,6 +304,8 @@ typedef BOOL(CALLBACK* sir_once_fn)(PINIT_ONCE, PVOID, PVOID*);
 #  define __HAVE_STDC_SECURE_OR_EXT1__
 # elif defined(__STDC_LIB_EXT1__)
 #  define __HAVE_STDC_SECURE_OR_EXT1__
+# elif defined(__STDC_ALLOC_LIB__)
+#  define __HAVE_STDC_EXT2__
 # endif
 
 # if !defined(__MACOS__)

--- a/sirtextstyle.c
+++ b/sirtextstyle.c
@@ -31,7 +31,7 @@ const char* _sir_gettextstyle(sir_level level) {
     sir_level_style_tuple* map = _sir_locksection(SIRMI_TEXTSTYLE);
     if (!map) {
         _sir_seterror(_SIR_E_INTERNAL);
-        return false;
+        return NULL;
     }
 
     const char* found        = SIR_UNKNOWN;

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -76,19 +76,24 @@ int main(int argc, char** argv) {
     size_t to_run = 0;
 
     for (int n = 1; n < argc; n++) {
-        if (_sir_strsame(argv[n], _cl_arg_list[0].flag, strlen(_cl_arg_list[0].flag))) {
+        if (_sir_strsame(argv[n], _cl_arg_list[0].flag,
+            strnlen(_cl_arg_list[0].flag, SIR_MAXCLIFLAG))) {
             only = mark_test_to_run("performance");
             if (only)
                 to_run = 1;
-        } else if (_sir_strsame(argv[n], _cl_arg_list[1].flag, strlen(argv[n]))) {
+        } else if (_sir_strsame(argv[n], _cl_arg_list[1].flag,
+            strnlen(argv[n], SIR_MAXCLIFLAG))) {
             wait = true;
-        } else if (_sir_strsame(argv[n], _cl_arg_list[3].flag, strlen(argv[n]))) {
+        } else if (_sir_strsame(argv[n], _cl_arg_list[3].flag,
+            strnlen(argv[n], SIR_MAXCLIFLAG))) {
             print_test_list();
             return EXIT_SUCCESS;
-        } else if (_sir_strsame(argv[n], _cl_arg_list[4].flag, strlen(argv[n]))) {
+        } else if (_sir_strsame(argv[n], _cl_arg_list[4].flag,
+            strnlen(argv[n], SIR_MAXCLIFLAG))) {
             print_usage_info();
             return EXIT_SUCCESS;
-        } else if (_sir_strsame(argv[n], _cl_arg_list[2].flag, strlen(argv[n]))) {
+        } else if (_sir_strsame(argv[n], _cl_arg_list[2].flag,
+            strnlen(argv[n], SIR_MAXCLIFLAG))) {
             while (++n < argc) {
                 if (_sir_validstrnofail(argv[n])) {
                     if (*argv[n] == '-' || !mark_test_to_run(argv[n])) {
@@ -415,7 +420,7 @@ bool sirtest_rollandarchivefile(void) {
     if (pass) {
         /* write an (approximately) known quantity until we should have rolled */
         size_t written  = 0;
-        size_t linesize = strlen(line);
+        size_t linesize = strnlen(line, SIR_MAXMESSAGE);
 
         do {
             pass &= sir_debug("%s", line);
@@ -1202,8 +1207,8 @@ bool sirtest_filesystem(void) {
                 printf("\t_sir_getbasename: '%s'\n", PRN_STR(_basename));
 
                 /* the last strlen(_basename) chars of filename should match. */
-                size_t len    = strlen(_basename);
-                size_t offset = strlen(filename) - len;
+                size_t len    = strnlen(_basename, SIR_MAXPATH);
+                size_t offset = strnlen(filename, SIR_MAXPATH) - len;
                 size_t n      = 0;
 
                 while (n < len) {
@@ -1781,7 +1786,8 @@ long sirtimergetres(void) {
 bool mark_test_to_run(const char* name) {
     bool found = false;
     for (size_t t = 0; t < _sir_countof(sir_tests); t++) {
-        if (_sir_strsame(name, sir_tests[t].name, strlen(sir_tests[t].name))) {
+        if (_sir_strsame(name, sir_tests[t].name,
+            strnlen(sir_tests[t].name, SIR_MAXTESTNAME))) {
             found = sir_tests[t].run = true;
             break;
         }
@@ -1798,8 +1804,10 @@ void print_usage_info(void) {
 
     for (size_t i = 0; i < _sir_countof(_cl_arg_list); i++) {
         fprintf(stderr, "\t%s%s%s%s%s\n", _cl_arg_list[i].flag,
-            strlen(_cl_arg_list[i].usage) == 0 ? "" : "\t", _cl_arg_list[i].usage,
-            strlen(_cl_arg_list[i].usage) == 0 ? "\t" : " ", _cl_arg_list[i].desc);
+            strnlen(_cl_arg_list[i].usage, SIR_MAXUSAGE) == 0
+                ? "" : "\t", _cl_arg_list[i].usage,
+            strnlen(_cl_arg_list[i].usage, SIR_MAXUSAGE) == 0
+                ? "\t" : " ", _cl_arg_list[i].desc);
     }
 
     fprintf(stderr, "\n");
@@ -1808,7 +1816,7 @@ void print_usage_info(void) {
 void print_test_list(void) {
     size_t longest = 0;
     for (size_t i = 0; i < _sir_countof(sir_tests); i++) {
-        size_t len = strlen(sir_tests[i].name);
+        size_t len = strnlen(sir_tests[i].name, SIR_MAXTESTNAME);
         if (len > longest)
             longest = len;
     }
@@ -1818,7 +1826,7 @@ void print_test_list(void) {
     for (size_t i = 0; i < _sir_countof(sir_tests); i++) {
         printf("\t%s\t", sir_tests[i].name);
 
-        size_t len = strlen(sir_tests[i].name);
+        size_t len = strnlen(sir_tests[i].name, SIR_MAXTESTNAME);
         if (len < longest)
             for (size_t n = len; n < longest; n++)
                 printf(" ");

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -70,6 +70,10 @@
 # define PRN_PASS(pass) ((pass) ? GREENB("PASS") : REDB("FAIL"))
 # define INDENT_ITEM "\t  " SIR_BULLET " "
 
+# define SIR_MAXTESTNAME 32
+# define SIR_MAXCLIFLAG  32
+# define SIR_MAXUSAGE    256
+
 /**
  * @defgroup tests Tests
  *


### PR DESCRIPTION
Will you look this over, and make sure I didn't botch anything? The flawfinder stuff is pretty straightforward:

- use strnlen instead of strlen
- use strlcpy/strlcat when available instead of strncpy/strncat

I moved a few things around to better fit the format that was already in place (i.e. where platform-specific includes are placed, etc.), and broke some long lines.