### PR TITLE
Add support for Oracle Developer Studio C and MinGW‑w64.

### DIFF
--- a/sirconfig.h
+++ b/sirconfig.h
@@ -90,7 +90,11 @@
  *
  * @remark Only applies if ::SIRO_NOPID or ::SIRO_NOTID are not set.
  */
-# define SIR_PIDFORMAT "%d"
+# if defined(__MINGW64__)
+#  define SIR_PIDFORMAT "%lld"
+# else
+#  define SIR_PIDFORMAT "%d"
+# endif
 
 /**
  * The string to place between process and thread IDs.

--- a/sirconfig.h
+++ b/sirconfig.h
@@ -90,11 +90,7 @@
  *
  * @remark Only applies if ::SIRO_NOPID or ::SIRO_NOTID are not set.
  */
-# if defined(__MINGW64__)
-#  define SIR_PIDFORMAT "%lld"
-# else
-#  define SIR_PIDFORMAT "%d"
-# endif
+# define SIR_PIDFORMAT "%d"
 
 /**
  * The string to place between process and thread IDs.

--- a/sirfilesystem.c
+++ b/sirfilesystem.c
@@ -48,11 +48,18 @@ bool _sir_pathgetstat(const char* restrict path, struct stat* restrict st, sir_r
 # if defined(__MACOS__)
         int open_flags = O_SEARCH;
 # elif defined(__linux__)
+#  if !defined(__SUNPRO_C) && !defined(__SUNPRO_CC)
         int open_flags = O_PATH | O_DIRECTORY;
+#  else
+        int open_flags = O_DIRECTORY;
+#  endif
 # elif defined(__FreeBSD__) || defined(__CYGWIN__)
         int open_flags = O_EXEC | O_DIRECTORY;
-# elif defined(__SOLARIS__) || defined(__NetBSD__) || defined(__DragonFly__) || defined(__HAIKU__)
+# elif defined(__SOLARIS__) || defined(__DragonFly__) || \
+       defined(__NetBSD__) || defined(__HAIKU__)
         int open_flags = O_DIRECTORY;
+# else
+#  error "unknown for your platform; please contact the author."
 # endif
 
         int fd = open(base_path, open_flags);

--- a/sirinternal.c
+++ b/sirinternal.c
@@ -146,7 +146,11 @@ bool _sir_init(sirinit* si) {
 
     _cfg->state.pid = _sir_getpid();
 
-    if (0 > snprintf(_cfg->state.pidbuf, SIR_MAXPID, SIR_PIDFORMAT, _cfg->state.pid))
+    if (0 > snprintf(_cfg->state.pidbuf, SIR_MAXPID, SIR_PIDFORMAT,
+#if defined(__MINGW64__)
+                     (int)
+#endif
+                     _cfg->state.pid))
         _sir_handleerr(errno);
 
 #if !defined(SIR_NO_SYSTEM_LOGGERS)
@@ -586,7 +590,11 @@ bool _sir_logv(sir_level level, const char* format, va_list args) {
     pid_t tid = _sir_gettid();
     if (tid != tmpcfg.state.pid) {
         if (!_sir_getthreadname(buf.tid)) {
-            if (0 > snprintf(buf.tid, SIR_MAXPID, SIR_PIDFORMAT, tid))
+            if (0 > snprintf(buf.tid, SIR_MAXPID, SIR_PIDFORMAT,
+#if defined(__MINGW64__)
+                             (int)
+#endif
+                             tid))
                 _sir_handleerr(errno);
         }
     }

--- a/sirinternal.c
+++ b/sirinternal.c
@@ -147,10 +147,7 @@ bool _sir_init(sirinit* si) {
     _cfg->state.pid = _sir_getpid();
 
     if (0 > snprintf(_cfg->state.pidbuf, SIR_MAXPID, SIR_PIDFORMAT,
-#if defined(__MINGW64__)
-                     (int)
-#endif
-                     _cfg->state.pid))
+                     PID_CAST _cfg->state.pid))
         _sir_handleerr(errno);
 
 #if !defined(SIR_NO_SYSTEM_LOGGERS)
@@ -590,11 +587,7 @@ bool _sir_logv(sir_level level, const char* format, va_list args) {
     pid_t tid = _sir_gettid();
     if (tid != tmpcfg.state.pid) {
         if (!_sir_getthreadname(buf.tid)) {
-            if (0 > snprintf(buf.tid, SIR_MAXPID, SIR_PIDFORMAT,
-#if defined(__MINGW64__)
-                             (int)
-#endif
-                             tid))
+            if (0 > snprintf(buf.tid, SIR_MAXPID, SIR_PIDFORMAT, PID_CAST tid))
                 _sir_handleerr(errno);
         }
     }

--- a/sirplatform.h
+++ b/sirplatform.h
@@ -160,6 +160,7 @@ int pthread_getname_np(pthread_t thread, char* buffer, size_t length);
 #  include <direct.h>
 #  if defined(__MINGW32__) || defined(__MINGW64__)
 #   define __USE_MINGW_ANSI_STDIO 1
+#   include <pthread.h>
 typedef  /* Workaround a MinGW bug */
 void (__cdecl* _invalid_parameter_handler)(
  wchar_t const*, wchar_t const*, wchar_t const*,
@@ -295,10 +296,6 @@ typedef void (*sir_once_fn)(void);
 #  define SIR_ONCE_INIT PTHREAD_ONCE_INIT
 
 # else /* __WIN__ */
-
-#  if defined(__MINGW32__) || defined(__MINGW64__)
-#   include <pthread.h>
-#  endif
 
 #  define SIR_MAXPATH MAX_PATH
 

--- a/sirplatform.h
+++ b/sirplatform.h
@@ -171,6 +171,12 @@ _set_thread_local_invalid_parameter_handler(
 #  endif
 # endif
 
+# if defined(__MINGW64__)
+#  define PID_CAST (int)
+# else
+#  define PID_CAST
+# endif
+
 # if defined(SIR_ASSERT_ENABLED)
 #  include <assert.h>
 #  define SIR_ASSERT(...) assert(__VA_ARGS__)

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -1539,10 +1539,7 @@ unsigned sirtest_thread(void* arg) {
     }
 
     printf("\thi, i'm thread id %d, logging to: '%s'...\n",
-#if defined(__MINGW64__)
-            (int)
-#endif
-            threadid, my_args->log_file);
+            PID_CAST threadid, my_args->log_file);
 
     for (size_t n = 0; n < 1000; n++) {
         /* choose a random level, and colors. */

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -1538,8 +1538,11 @@ unsigned sirtest_thread(void* arg) {
 #endif
     }
 
-    printf("\thi, i'm thread id %lld, logging to: '%s'...\n",
-            (long long)threadid, my_args->log_file);
+    printf("\thi, i'm thread id %d, logging to: '%s'...\n",
+#if defined(__MINGW64__)
+            (int)
+#endif
+            threadid, my_args->log_file);
 
     for (size_t n = 0; n < 1000; n++) {
         /* choose a random level, and colors. */

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -1538,7 +1538,8 @@ unsigned sirtest_thread(void* arg) {
 #endif
     }
 
-    printf("\thi, i'm thread id %d, logging to: '%s'...\n", threadid, my_args->log_file);
+    printf("\thi, i'm thread id %lld, logging to: '%s'...\n",
+            (long long)threadid, my_args->log_file);
 
     for (size_t n = 0; n < 1000; n++) {
         /* choose a random level, and colors. */


### PR DESCRIPTION
* Tested with [Oracle Developer Studio](https://www.oracle.com/application-development/technologies/developerstudio.html) C/C++ 12.6 on Linux and Solaris.
[]()
[]()
* Tested with [MinGW-w64](https://www.mingw-w64.org/) on Fedora, Ubuntu, and Cygwin, targeting:
  * 64-bit UCRT: `make CC=x86_64-mingw32ucrt-gcc`
  * 64-bit MSVCRT: `make SIR_MSVCRT_MINGW=1 CC=x86_64-mingw32-gcc`
  * 32-bit MSVCRT: `make SIR_MSVCRT_MINGW=1 CC=i686-w64-mingw32-gcc`
    