### PR TITLE
Suppress Clang Analyzer and Cppcheck warnings

### DIFF
--- a/sirhelpers.c
+++ b/sirhelpers.c
@@ -195,7 +195,7 @@ int _sir_strncpy(char* restrict dest, size_t destsz, const char* restrict src, s
             return -1;
         }
         return 0;
-#elif defined(__MACOS__) || defined(__BSD__)
+#elif defined(__MACOS__) || defined(__BSD__) || defined(__SOLARIS__)
         _SIR_UNUSED(count);
         size_t cpy = strlcpy(dest, src, destsz);
         SIR_ASSERT(cpy < destsz);
@@ -220,7 +220,7 @@ int _sir_strncat(char* restrict dest, size_t destsz, const char* restrict src, s
             return -1;
         }
         return 0;
-#elif defined(__MACOS__) || defined(__BSD__)
+#elif defined(__MACOS__) || defined(__BSD__) || defined(__SOLARIS__)
         _SIR_UNUSED(count);
         size_t cat = strlcat(dest, src, destsz);
         SIR_ASSERT(cat < destsz);

--- a/sirtextstyle.c
+++ b/sirtextstyle.c
@@ -267,19 +267,31 @@ bool _sir_validstyle(sir_textstyle style, uint32_t* pattr, uint32_t* pfg, uint32
     }
 
 #if !defined(__clang_analyzer__)
-    if (_sir_validptrnofail(pattr))
+    if (_sir_validptrnofail(pattr)) {
 #endif
+        /* cppcheck-suppress nullPointer */
         *pattr = attrvalid ? attr : 0;
+#if !defined(__clang_analyzer__)
+    }
+#endif
 
 #if !defined(__clang_analyzer__)
-    if (_sir_validptrnofail(pfg))
+    if (_sir_validptrnofail(pfg)) {
 #endif
+        /* cppcheck-suppress nullPointer */
         *pfg = fgvalid ? fore : 0;
+#if !defined(__clang_analyzer__)
+    }
+#endif
 
 #if !defined(__clang_analyzer__)
-    if (_sir_validptrnofail(pbg))
+    if (_sir_validptrnofail(pbg)) {
 #endif
+        /* cppcheck-suppress nullPointer */
         *pbg = bgvalid ? back : 0;
+#if !defined(__clang_analyzer__)
+    }
+#endif
 
     if (attrvalid && fgvalid && bgvalid)
         return true;

--- a/sirtextstyle.c
+++ b/sirtextstyle.c
@@ -266,13 +266,19 @@ bool _sir_validstyle(sir_textstyle style, uint32_t* pattr, uint32_t* pfg, uint32
         }
     }
 
+#if !defined(__clang_analyzer__)
     if (_sir_validptrnofail(pattr))
+#endif
         *pattr = attrvalid ? attr : 0;
 
+#if !defined(__clang_analyzer__)
     if (_sir_validptrnofail(pfg))
+#endif
         *pfg = fgvalid ? fore : 0;
 
+#if !defined(__clang_analyzer__)
     if (_sir_validptrnofail(pbg))
+#endif
         *pbg = bgvalid ? back : 0;
 
     if (attrvalid && fgvalid && bgvalid)


### PR DESCRIPTION
@aremmell While it still bothers me a bit still that both analyzers flag this, if you want, we can dismiss with these exclusions.