### PR TITLE
Don't test os_log activity feature if built with Intel C++ Compiler Classic for macOS

### DIFF
--- a/tests/tests.c
+++ b/tests/tests.c
@@ -1137,6 +1137,7 @@ static bool generic_syslog_test(const char* sl_name, const char* identity, const
         pass &= sir_emerg("%d/%d: this emergency message sent to stdout and %s.", i + 1, runs, sl_name);
 
 # if defined(SIR_OS_LOG_ENABLED)
+#  if defined(__APPLE__) && !defined(__INTEL_COMPILER)
         if (i == runs -1 && 0 == strncmp(sl_name, "os_log", 6)) {
             printf("\ttesting os_log activity feature...\n");
 
@@ -1149,6 +1150,7 @@ static bool generic_syslog_test(const char* sl_name, const char* identity, const
             * will occur, then a sub-activity will be created, and more logging. */
             os_activity_apply_f(parent, (void*)parent, os_log_parent_activity);
         }
+#  endif
 # endif
 
         sir_cleanup();


### PR DESCRIPTION
ICC doesn't support OS_ACTIVITY_OBJECT_API due to <10.12 target.  (No great loss, as Intel C++ Compiler Classic is deprecated and will be EOL sometime "in the second half of 2023").