### PR TITLE
Add all *.d to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ index.md
 # Visual Studio temporary files
 .vs/
 *.user
+
+# Automatic dependencies
+*.d


### PR DESCRIPTION
*  Add all *.d to `.gitignore`

Chibcc and old XL C seems to (incorrectly) drop them into the current working directory.