### PR TITLE
GNU Makefile improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ index.md
 
 # Automatic dependencies
 *.d
+
+# Advpng temporary files
+*.png.tmp*

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ $(OUT_TESTS): $(OUT_STATIC) $(OBJ_TESTS)
 	@mkdir -p $(@D)
 	@mkdir -p $(BINDIR)
 	$(CC) -o $(OUT_TESTS) $(OBJ_TESTS) $(CFLAGS) -I.. $(LDFLAGS)
-	$(shell touch $(BINDIR)/file.exists)
+	@touch $(BINDIR)/file.exists > /dev/null
 	-@echo built $(OUT_TESTS) successfully.
 
 .PHONY: docs

--- a/Makefile
+++ b/Makefile
@@ -94,91 +94,91 @@ all: $(OUT_SHARED) $(OUT_STATIC) $(OUT_EXAMPLE) $(OUT_TESTS)
 
 -include $(INTDIR)/*.d
 
-.RECIPEPREFIX = ~
+.RECIPEPREFIX = :
 
 $(OBJ_EXAMPLE): $(EXAMPLE)/$(EXAMPLE).c $(DEPS)
-~  @mkdir -p $(@D)
-~  $(CC) $(MMDOPT) -c -o $@ $< $(CFLAGS) -I..
+:  @mkdir -p $(@D)
+:  $(CC) $(MMDOPT) -c -o $@ $< $(CFLAGS) -I..
 
 $(OBJ_TESTS): $(TESTS)/$(TESTS).c $(DEPS)
-~  @mkdir -p $(@D)
-~  $(CC) $(MMDOPT) -c -o $@ $< $(CFLAGS) -I..
+:  @mkdir -p $(@D)
+:  $(CC) $(MMDOPT) -c -o $@ $< $(CFLAGS) -I..
 
 $(INTDIR)/%.o: %.c $(DEPS)
-~  @mkdir -p $(@D)
-~  $(CC) $(MMDOPT) -c -o $@ $< $(CFLAGS)
+:  @mkdir -p $(@D)
+:  $(CC) $(MMDOPT) -c -o $@ $< $(CFLAGS)
 
 .PHONY: shared
 shared: $(OUT_SHARED)
 $(OUT_SHARED): $(OBJ_SHARED)
-~  @mkdir -p $(@D)
-~  $(CC) -shared -o $(OUT_SHARED) $^ $(CFLAGS) $(LDFLAGS_SHARED)
-~  -@echo built $(OUT_SHARED) successfully.
+:  @mkdir -p $(@D)
+:  $(CC) -shared -o $(OUT_SHARED) $^ $(CFLAGS) $(LDFLAGS_SHARED)
+:  -@echo built $(OUT_SHARED) successfully.
 
 .PHONY: static
 static: $(OUT_STATIC)
 $(OUT_STATIC): $(OUT_SHARED)
-~  @mkdir -p $(@D)
-~  ar -cr $(OUT_STATIC) $(OBJ_SHARED)
-~  -@($(RANLIB) "$(OUT_STATIC)" || true) > /dev/null 2>&1
-~  -@echo built $(OUT_STATIC) successfully.
+:  @mkdir -p $(@D)
+:  ar -cr $(OUT_STATIC) $(OBJ_SHARED)
+:  -@($(RANLIB) "$(OUT_STATIC)" || true) > /dev/null 2>&1
+:  -@echo built $(OUT_STATIC) successfully.
 
 .PHONY: example
 example: $(OUT_EXAMPLE)
 $(OUT_EXAMPLE): $(OUT_STATIC) $(OBJ_EXAMPLE)
-~  @mkdir -p $(@D)
-~  @mkdir -p $(BINDIR)
-~  $(CC) -o $(OUT_EXAMPLE) $(OBJ_EXAMPLE) $(CFLAGS) -I.. $(LDFLAGS)
-~  -@echo built $(OUT_EXAMPLE) successfully.
+:  @mkdir -p $(@D)
+:  @mkdir -p $(BINDIR)
+:  $(CC) -o $(OUT_EXAMPLE) $(OBJ_EXAMPLE) $(CFLAGS) -I.. $(LDFLAGS)
+:  -@echo built $(OUT_EXAMPLE) successfully.
 
 $(BINDIR)/file.exists:
-~  @touch $(BINDIR)/file.exists > /dev/null
+:  @touch $(BINDIR)/file.exists > /dev/null
 
 .PHONY: tests
 tests: $(OUT_TESTS) $(BINDIR)/file.exists
 $(OUT_TESTS): $(OUT_STATIC) $(OBJ_TESTS)
-~  @mkdir -p $(@D)
-~  @mkdir -p $(BINDIR)
-~  $(CC) -o $(OUT_TESTS) $(OBJ_TESTS) $(CFLAGS) -I.. $(LDFLAGS)
-~  -@echo built $(OUT_TESTS) successfully.
+:  @mkdir -p $(@D)
+:  @mkdir -p $(BINDIR)
+:  $(CC) -o $(OUT_TESTS) $(OBJ_TESTS) $(CFLAGS) -I.. $(LDFLAGS)
+:  -@echo built $(OUT_TESTS) successfully.
 
 .PHONY: docs
 docs: $(OUT_STATIC)
-~  @doxygen Doxyfile
-~  -@find docs -name '*.png' -exec advpng -z4 "{}" \
+:  @doxygen Doxyfile
+:  -@find docs -name '*.png' -exec advpng -z4 "{}" \
       2> /dev/null \; 2> /dev/null || true
-~  -@echo built documentation successfully.
+:  -@echo built documentation successfully.
 
 .PHONY: install
 install: $(INSTALLSH)
-~  @test -x $(INSTALLSH) || \
+:  @test -x $(INSTALLSH) || \
       { printf 'Error: %s not executable.\n' "$(INSTALLSH)"; exit 1; }
-~  +@test -f "$(OUT_STATIC)" || $(MAKE) static
-~  +@test -f "$(OUT_SHARED)" || $(MAKE) shared
-~  -@echo installing libraries to $(INSTALLLIB) and headers to $(INSTALLINC)...
-~  $(INSTALLSH) -C -m 755 "$(OUT_SHARED)" "$(INSTALLLIB)"
-~  -($(LDCONFIG) || true) > /dev/null 2>&1
-~  $(INSTALLSH) -C -m 644 "$(OUT_STATIC)" "$(INSTALLLIB)"
-~  -($(RANLIB) "$(INSTALLLIB)/$(OUT_STATIC_FN)" || true) > /dev/null 2>&1
-~  $(INSTALLSH) -C -m 644 "sir.h" "$(INSTALLINC)"
-~  -@echo installed libsir successfully.
+:  +@test -f "$(OUT_STATIC)" || $(MAKE) static
+:  +@test -f "$(OUT_SHARED)" || $(MAKE) shared
+:  -@echo installing libraries to $(INSTALLLIB) and headers to $(INSTALLINC)...
+:  $(INSTALLSH) -C -m 755 "$(OUT_SHARED)" "$(INSTALLLIB)"
+:  -($(LDCONFIG) || true) > /dev/null 2>&1
+:  $(INSTALLSH) -C -m 644 "$(OUT_STATIC)" "$(INSTALLLIB)"
+:  -($(RANLIB) "$(INSTALLLIB)/$(OUT_STATIC_FN)" || true) > /dev/null 2>&1
+:  $(INSTALLSH) -C -m 644 "sir.h" "$(INSTALLINC)"
+:  -@echo installed libsir successfully.
 
 .PHONY: clean distclean
 clean distclean:
-~  @rm -rf $(BUILDDIR) > /dev/null 2>&1
-~  @rm -rf ./*.log > /dev/null 2>&1
-~  @rm -rf ./*.d > /dev/null 2>&1
-~  -@echo build directory and log files cleaned successfully.
+:  @rm -rf $(BUILDDIR) > /dev/null 2>&1
+:  @rm -rf ./*.log > /dev/null 2>&1
+:  @rm -rf ./*.d > /dev/null 2>&1
+:  -@echo build directory and log files cleaned successfully.
 
 .PHONY: printvars printenv
 printvars printenv:
-~  -@printf '%s: ' "FEATURES"; printf '%s ' "$(.FEATURES)"; printf '%s\n' ""
-~  -@$(foreach V,$(sort $(.VARIABLES)), \
+:  -@printf '%s: ' "FEATURES"; printf '%s ' "$(.FEATURES)"; printf '%s\n' ""
+:  -@$(foreach V,$(sort $(.VARIABLES)), \
       $(if $(filter-out environment% default automatic,$(origin $V)), \
         $(if $(strip $($V)),$(info $V: [$($V)]),)))
-~  -@true > /dev/null 2>&1
+:  -@true > /dev/null 2>&1
 
 .PHONY: print-%
 print-%:
-~  -@$(info $*: [$($*)] ($(flavor $*). set by $(origin $*)))@true
-~  -@true > /dev/null 2>&1
+:  -@$(info $*: [$($*)] ($(flavor $*). set by $(origin $*)))@true
+:  -@true > /dev/null 2>&1

--- a/Makefile
+++ b/Makefile
@@ -128,13 +128,15 @@ $(OUT_EXAMPLE): $(OUT_STATIC) $(OBJ_EXAMPLE)
 	$(CC) -o $(OUT_EXAMPLE) $(OBJ_EXAMPLE) $(CFLAGS) -I.. $(LDFLAGS)
 	-@echo built $(OUT_EXAMPLE) successfully.
 
+$(BINDIR)/file.exists:
+	@touch $(BINDIR)/file.exists > /dev/null
+
 .PHONY: tests
-tests: $(OUT_TESTS)
+tests: $(OUT_TESTS) $(BINDIR)/file.exists
 $(OUT_TESTS): $(OUT_STATIC) $(OBJ_TESTS)
 	@mkdir -p $(@D)
 	@mkdir -p $(BINDIR)
 	$(CC) -o $(OUT_TESTS) $(OBJ_TESTS) $(CFLAGS) -I.. $(LDFLAGS)
-	@touch $(BINDIR)/file.exists > /dev/null
 	-@echo built $(OUT_TESTS) successfully.
 
 .PHONY: docs

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ EXAMPLE     = example
 INTDIR      = $(BUILDDIR)/obj
 LIBDIR      = $(BUILDDIR)/lib
 BINDIR      = $(BUILDDIR)/bin
-PREFIX     ?= $(DESTDIR)/usr/local
-INSTALLLIB  = $(PREFIX)/lib
-INSTALLINC  = $(PREFIX)/include
-INSTALLSH   = build-aux/install-sh
+PREFIX     ?= /usr/local
+INSTALLLIB  = $(DESTDIR)$(PREFIX)/lib
+INSTALLINC  = $(DESTDIR)$(PREFIX)/include
+INSTALLSH   = ./build-aux/install-sh
 RANLIB     ?= ranlib
 LDCONFIG   ?= ldconfig
 SHELL      := $(shell env sh -c 'PATH="$$(command -p getconf PATH)" command -v sh')

--- a/Makefile
+++ b/Makefile
@@ -94,91 +94,89 @@ all: $(OUT_SHARED) $(OUT_STATIC) $(OUT_EXAMPLE) $(OUT_TESTS)
 
 -include $(INTDIR)/*.d
 
-.RECIPEPREFIX = :
-
 $(OBJ_EXAMPLE): $(EXAMPLE)/$(EXAMPLE).c $(DEPS)
-:  @mkdir -p $(@D)
-:  $(CC) $(MMDOPT) -c -o $@ $< $(CFLAGS) -I..
+	@mkdir -p $(@D)
+	$(CC) $(MMDOPT) -c -o $@ $< $(CFLAGS) -I..
 
 $(OBJ_TESTS): $(TESTS)/$(TESTS).c $(DEPS)
-:  @mkdir -p $(@D)
-:  $(CC) $(MMDOPT) -c -o $@ $< $(CFLAGS) -I..
+	@mkdir -p $(@D)
+	$(CC) $(MMDOPT) -c -o $@ $< $(CFLAGS) -I..
 
 $(INTDIR)/%.o: %.c $(DEPS)
-:  @mkdir -p $(@D)
-:  $(CC) $(MMDOPT) -c -o $@ $< $(CFLAGS)
+	@mkdir -p $(@D)
+	$(CC) $(MMDOPT) -c -o $@ $< $(CFLAGS)
 
 .PHONY: shared
 shared: $(OUT_SHARED)
 $(OUT_SHARED): $(OBJ_SHARED)
-:  @mkdir -p $(@D)
-:  $(CC) -shared -o $(OUT_SHARED) $^ $(CFLAGS) $(LDFLAGS_SHARED)
-:  -@echo built $(OUT_SHARED) successfully.
+	@mkdir -p $(@D)
+	$(CC) -shared -o $(OUT_SHARED) $^ $(CFLAGS) $(LDFLAGS_SHARED)
+	-@echo built $(OUT_SHARED) successfully.
 
 .PHONY: static
 static: $(OUT_STATIC)
 $(OUT_STATIC): $(OUT_SHARED)
-:  @mkdir -p $(@D)
-:  ar -cr $(OUT_STATIC) $(OBJ_SHARED)
-:  -@($(RANLIB) "$(OUT_STATIC)" || true) > /dev/null 2>&1
-:  -@echo built $(OUT_STATIC) successfully.
+	@mkdir -p $(@D)
+	ar -cr $(OUT_STATIC) $(OBJ_SHARED)
+	-@($(RANLIB) "$(OUT_STATIC)" || true) > /dev/null 2>&1
+	-@echo built $(OUT_STATIC) successfully.
 
 .PHONY: example
 example: $(OUT_EXAMPLE)
 $(OUT_EXAMPLE): $(OUT_STATIC) $(OBJ_EXAMPLE)
-:  @mkdir -p $(@D)
-:  @mkdir -p $(BINDIR)
-:  $(CC) -o $(OUT_EXAMPLE) $(OBJ_EXAMPLE) $(CFLAGS) -I.. $(LDFLAGS)
-:  -@echo built $(OUT_EXAMPLE) successfully.
+	@mkdir -p $(@D)
+	@mkdir -p $(BINDIR)
+	$(CC) -o $(OUT_EXAMPLE) $(OBJ_EXAMPLE) $(CFLAGS) -I.. $(LDFLAGS)
+	-@echo built $(OUT_EXAMPLE) successfully.
 
 $(BINDIR)/file.exists:
-:  @touch $(BINDIR)/file.exists > /dev/null
+	@touch $(BINDIR)/file.exists > /dev/null
 
 .PHONY: tests
 tests: $(OUT_TESTS) $(BINDIR)/file.exists
 $(OUT_TESTS): $(OUT_STATIC) $(OBJ_TESTS)
-:  @mkdir -p $(@D)
-:  @mkdir -p $(BINDIR)
-:  $(CC) -o $(OUT_TESTS) $(OBJ_TESTS) $(CFLAGS) -I.. $(LDFLAGS)
-:  -@echo built $(OUT_TESTS) successfully.
+	@mkdir -p $(@D)
+	@mkdir -p $(BINDIR)
+	$(CC) -o $(OUT_TESTS) $(OBJ_TESTS) $(CFLAGS) -I.. $(LDFLAGS)
+	-@echo built $(OUT_TESTS) successfully.
 
 .PHONY: docs
 docs: $(OUT_STATIC)
-:  @doxygen Doxyfile
-:  -@find docs -name '*.png' -exec advpng -z4 "{}" \
-      2> /dev/null \; 2> /dev/null || true
-:  -@echo built documentation successfully.
+	@doxygen Doxyfile
+	-@find docs -name '*.png' -exec advpng -z4 "{}" \
+		2> /dev/null \; 2> /dev/null || true
+	-@echo built documentation successfully.
 
 .PHONY: install
 install: $(INSTALLSH)
-:  @test -x $(INSTALLSH) || \
-      { printf 'Error: %s not executable.\n' "$(INSTALLSH)"; exit 1; }
-:  +@test -f "$(OUT_STATIC)" || $(MAKE) static
-:  +@test -f "$(OUT_SHARED)" || $(MAKE) shared
-:  -@echo installing libraries to $(INSTALLLIB) and headers to $(INSTALLINC)...
-:  $(INSTALLSH) -C -m 755 "$(OUT_SHARED)" "$(INSTALLLIB)"
-:  -($(LDCONFIG) || true) > /dev/null 2>&1
-:  $(INSTALLSH) -C -m 644 "$(OUT_STATIC)" "$(INSTALLLIB)"
-:  -($(RANLIB) "$(INSTALLLIB)/$(OUT_STATIC_FN)" || true) > /dev/null 2>&1
-:  $(INSTALLSH) -C -m 644 "sir.h" "$(INSTALLINC)"
-:  -@echo installed libsir successfully.
+	@test -x $(INSTALLSH) || \
+		{ printf 'Error: %s not executable.\n' "$(INSTALLSH)"; exit 1; }
+	+@test -f "$(OUT_STATIC)" || $(MAKE) static
+	+@test -f "$(OUT_SHARED)" || $(MAKE) shared
+	-@echo installing libraries to $(INSTALLLIB) and headers to $(INSTALLINC)...
+	$(INSTALLSH) -C -m 755 "$(OUT_SHARED)" "$(INSTALLLIB)"
+	-($(LDCONFIG) || true) > /dev/null 2>&1
+	$(INSTALLSH) -C -m 644 "$(OUT_STATIC)" "$(INSTALLLIB)"
+	-($(RANLIB) "$(INSTALLLIB)/$(OUT_STATIC_FN)" || true) > /dev/null 2>&1
+	$(INSTALLSH) -C -m 644 "sir.h" "$(INSTALLINC)"
+	-@echo installed libsir successfully.
 
 .PHONY: clean distclean
 clean distclean:
-:  @rm -rf $(BUILDDIR) > /dev/null 2>&1
-:  @rm -rf ./*.log > /dev/null 2>&1
-:  @rm -rf ./*.d > /dev/null 2>&1
-:  -@echo build directory and log files cleaned successfully.
+	@rm -rf $(BUILDDIR) > /dev/null 2>&1
+	@rm -rf ./*.log > /dev/null 2>&1
+	@rm -rf ./*.d > /dev/null 2>&1
+	-@echo build directory and log files cleaned successfully.
 
 .PHONY: printvars printenv
 printvars printenv:
-:  -@printf '%s: ' "FEATURES"; printf '%s ' "$(.FEATURES)"; printf '%s\n' ""
-:  -@$(foreach V,$(sort $(.VARIABLES)), \
-      $(if $(filter-out environment% default automatic,$(origin $V)), \
-        $(if $(strip $($V)),$(info $V: [$($V)]),)))
-:  -@true > /dev/null 2>&1
+	-@printf '%s: ' "FEATURES"; printf '%s ' "$(.FEATURES)"; printf '%s\n' ""
+	-@$(foreach V,$(sort $(.VARIABLES)), \
+		$(if $(filter-out environment% default automatic,$(origin $V)), \
+			$(if $(strip $($V)),$(info $V: [$($V)]),)))
+	-@true > /dev/null 2>&1
 
 .PHONY: print-%
 print-%:
-:  -@$(info $*: [$($*)] ($(flavor $*). set by $(origin $*)))@true
-:  -@true > /dev/null 2>&1
+	-@$(info $*: [$($*)] ($(flavor $*). set by $(origin $*)))@true
+	-@true > /dev/null 2>&1

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ docs: $(OUT_STATIC)
 .PHONY: install
 install: $(INSTALLSH)
 	@test -x $(INSTALLSH) || \
-		{ printf 'Error: %s not executable.\n' "$(INSTALLSH)"; exit 1; }
+	  { printf 'Error: %s not executable.\n' "$(INSTALLSH)"; exit 1; }
 	+@test -f "$(OUT_STATIC)" || $(MAKE) static
 	+@test -f "$(OUT_SHARED)" || $(MAKE) shared
 	-@echo installing libraries to $(INSTALLLIB) and headers to $(INSTALLINC)...
@@ -170,8 +170,8 @@ clean distclean:
 .PHONY: printvars printenv
 printvars printenv:
 	-@$(foreach V,$(sort $(.VARIABLES)), \
-		$(if $(filter-out environment% default automatic,$(origin $V)), \
-		$(if $(strip $($V)),$(info $V: [$($V)]),)))
+	  $(if $(filter-out environment% default automatic,$(origin $V)), \
+	    $(if $(strip $($V)),$(info $V: [$($V)]),)))
 	-@true > /dev/null 2>&1
 
 .PHONY: print-%

--- a/Makefile
+++ b/Makefile
@@ -88,93 +88,97 @@ OUT_TESTS      = $(BINDIR)/sirtests$(PLATFORM_EXE_EXT)
 # targets
 # ##########
 
+.DEFAULT_GOAL := all
 .PHONY: all
 all: $(OUT_SHARED) $(OUT_STATIC) $(OUT_EXAMPLE) $(OUT_TESTS)
 
 -include $(INTDIR)/*.d
 
+.RECIPEPREFIX = ~
+
 $(OBJ_EXAMPLE): $(EXAMPLE)/$(EXAMPLE).c $(DEPS)
-	@mkdir -p $(@D)
-	$(CC) $(MMDOPT) -c -o $@ $< $(CFLAGS) -I..
+~  @mkdir -p $(@D)
+~  $(CC) $(MMDOPT) -c -o $@ $< $(CFLAGS) -I..
 
 $(OBJ_TESTS): $(TESTS)/$(TESTS).c $(DEPS)
-	@mkdir -p $(@D)
-	$(CC) $(MMDOPT) -c -o $@ $< $(CFLAGS) -I..
+~  @mkdir -p $(@D)
+~  $(CC) $(MMDOPT) -c -o $@ $< $(CFLAGS) -I..
 
 $(INTDIR)/%.o: %.c $(DEPS)
-	@mkdir -p $(@D)
-	$(CC) $(MMDOPT) -c -o $@ $< $(CFLAGS)
+~  @mkdir -p $(@D)
+~  $(CC) $(MMDOPT) -c -o $@ $< $(CFLAGS)
 
 .PHONY: shared
 shared: $(OUT_SHARED)
 $(OUT_SHARED): $(OBJ_SHARED)
-	@mkdir -p $(@D)
-	$(CC) -shared -o $(OUT_SHARED) $^ $(CFLAGS) $(LDFLAGS_SHARED)
-	-@echo built $(OUT_SHARED) successfully.
+~  @mkdir -p $(@D)
+~  $(CC) -shared -o $(OUT_SHARED) $^ $(CFLAGS) $(LDFLAGS_SHARED)
+~  -@echo built $(OUT_SHARED) successfully.
 
 .PHONY: static
 static: $(OUT_STATIC)
 $(OUT_STATIC): $(OUT_SHARED)
-	@mkdir -p $(@D)
-	ar -cr $(OUT_STATIC) $(OBJ_SHARED)
-	-@($(RANLIB) "$(OUT_STATIC)" || true) > /dev/null 2>&1
-	-@echo built $(OUT_STATIC) successfully.
+~  @mkdir -p $(@D)
+~  ar -cr $(OUT_STATIC) $(OBJ_SHARED)
+~  -@($(RANLIB) "$(OUT_STATIC)" || true) > /dev/null 2>&1
+~  -@echo built $(OUT_STATIC) successfully.
 
 .PHONY: example
 example: $(OUT_EXAMPLE)
 $(OUT_EXAMPLE): $(OUT_STATIC) $(OBJ_EXAMPLE)
-	@mkdir -p $(@D)
-	@mkdir -p $(BINDIR)
-	$(CC) -o $(OUT_EXAMPLE) $(OBJ_EXAMPLE) $(CFLAGS) -I.. $(LDFLAGS)
-	-@echo built $(OUT_EXAMPLE) successfully.
+~  @mkdir -p $(@D)
+~  @mkdir -p $(BINDIR)
+~  $(CC) -o $(OUT_EXAMPLE) $(OBJ_EXAMPLE) $(CFLAGS) -I.. $(LDFLAGS)
+~  -@echo built $(OUT_EXAMPLE) successfully.
 
 $(BINDIR)/file.exists:
-	@touch $(BINDIR)/file.exists > /dev/null
+~  @touch $(BINDIR)/file.exists > /dev/null
 
 .PHONY: tests
 tests: $(OUT_TESTS) $(BINDIR)/file.exists
 $(OUT_TESTS): $(OUT_STATIC) $(OBJ_TESTS)
-	@mkdir -p $(@D)
-	@mkdir -p $(BINDIR)
-	$(CC) -o $(OUT_TESTS) $(OBJ_TESTS) $(CFLAGS) -I.. $(LDFLAGS)
-	-@echo built $(OUT_TESTS) successfully.
+~  @mkdir -p $(@D)
+~  @mkdir -p $(BINDIR)
+~  $(CC) -o $(OUT_TESTS) $(OBJ_TESTS) $(CFLAGS) -I.. $(LDFLAGS)
+~  -@echo built $(OUT_TESTS) successfully.
 
 .PHONY: docs
 docs: $(OUT_STATIC)
-	@doxygen Doxyfile
-	-@find docs -name '*.png' -exec advpng -z4 "{}" \
-	  2> /dev/null \; 2> /dev/null || true
-	-@echo built documentation successfully.
+~  @doxygen Doxyfile
+~  -@find docs -name '*.png' -exec advpng -z4 "{}" \
+      2> /dev/null \; 2> /dev/null || true
+~  -@echo built documentation successfully.
 
 .PHONY: install
 install: $(INSTALLSH)
-	@test -x $(INSTALLSH) || \
-	  { printf 'Error: %s not executable.\n' "$(INSTALLSH)"; exit 1; }
-	+@test -f "$(OUT_STATIC)" || $(MAKE) static
-	+@test -f "$(OUT_SHARED)" || $(MAKE) shared
-	-@echo installing libraries to $(INSTALLLIB) and headers to $(INSTALLINC)...
-	$(INSTALLSH) -C -m 755 "$(OUT_SHARED)" "$(INSTALLLIB)"
-	-($(LDCONFIG) || true) > /dev/null 2>&1
-	$(INSTALLSH) -C -m 644 "$(OUT_STATIC)" "$(INSTALLLIB)"
-	-($(RANLIB) "$(INSTALLLIB)/$(OUT_STATIC_FN)" || true) > /dev/null 2>&1
-	$(INSTALLSH) -C -m 644 "sir.h" "$(INSTALLINC)"
-	-@echo installed libsir successfully.
+~  @test -x $(INSTALLSH) || \
+      { printf 'Error: %s not executable.\n' "$(INSTALLSH)"; exit 1; }
+~  +@test -f "$(OUT_STATIC)" || $(MAKE) static
+~  +@test -f "$(OUT_SHARED)" || $(MAKE) shared
+~  -@echo installing libraries to $(INSTALLLIB) and headers to $(INSTALLINC)...
+~  $(INSTALLSH) -C -m 755 "$(OUT_SHARED)" "$(INSTALLLIB)"
+~  -($(LDCONFIG) || true) > /dev/null 2>&1
+~  $(INSTALLSH) -C -m 644 "$(OUT_STATIC)" "$(INSTALLLIB)"
+~  -($(RANLIB) "$(INSTALLLIB)/$(OUT_STATIC_FN)" || true) > /dev/null 2>&1
+~  $(INSTALLSH) -C -m 644 "sir.h" "$(INSTALLINC)"
+~  -@echo installed libsir successfully.
 
 .PHONY: clean distclean
 clean distclean:
-	@rm -rf $(BUILDDIR) > /dev/null 2>&1
-	@rm -rf ./*.log > /dev/null 2>&1
-	@rm -rf ./*.d > /dev/null 2>&1
-	-@echo build directory and log files cleaned successfully.
+~  @rm -rf $(BUILDDIR) > /dev/null 2>&1
+~  @rm -rf ./*.log > /dev/null 2>&1
+~  @rm -rf ./*.d > /dev/null 2>&1
+~  -@echo build directory and log files cleaned successfully.
 
 .PHONY: printvars printenv
 printvars printenv:
-	-@$(foreach V,$(sort $(.VARIABLES)), \
-	  $(if $(filter-out environment% default automatic,$(origin $V)), \
-	    $(if $(strip $($V)),$(info $V: [$($V)]),)))
-	-@true > /dev/null 2>&1
+~  -@printf '%s: ' "FEATURES"; printf '%s ' "$(.FEATURES)"; printf '%s\n' ""
+~  -@$(foreach V,$(sort $(.VARIABLES)), \
+      $(if $(filter-out environment% default automatic,$(origin $V)), \
+        $(if $(strip $($V)),$(info $V: [$($V)]),)))
+~  -@true > /dev/null 2>&1
 
 .PHONY: print-%
 print-%:
-	-@$(info $*: [$($*)] ($(flavor $*). set by $(origin $*)))@true
-	-@true > /dev/null 2>&1
+~  -@$(info $*: [$($*)] ($(flavor $*). set by $(origin $*)))@true
+~  -@true > /dev/null 2>&1

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,8 @@ $(OUT_TESTS): $(OUT_STATIC) $(OBJ_TESTS)
 .PHONY: docs
 docs: $(OUT_STATIC)
 	@doxygen Doxyfile
+	-@find docs -name '*.png' -exec advpng -z4 "{}" \
+	  2> /dev/null \; 2> /dev/null || true
 	-@echo built documentation successfully.
 
 .PHONY: install

--- a/sirplatform.mk
+++ b/sirplatform.mk
@@ -8,7 +8,7 @@
 
 # MinGW-w64 and standard Unix
 ifneq "$(findstring mingw,$(CC))" ""
-	MINGW?=1
+  MINGW?=1
 endif
 ifeq ($(MINGW),1)
   ifneq "$(findstring gcc,$(CC))" ""

--- a/sirplatform.mk
+++ b/sirplatform.mk
@@ -1,0 +1,71 @@
+#
+# libsir -- sirplatform.mk
+# https://github.com/aremmell/libsir
+#
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: Copyright (c) 2018-current Ryan M. Lederman
+#
+
+# MinGW-w64 and standard Unix
+ifneq "$(findstring mingw,$(CC))" ""
+	MINGW?=1
+endif
+ifeq ($(MINGW),1)
+  ifneq "$(findstring gcc,$(CC))" ""
+    CFLAGS+=-Wno-unknown-pragmas
+  endif
+  PLATFORM_DLL_EXT=.dll
+  PLATFORM_EXE_EXT=.exe
+  PLATFORM_LIB_EXT=.lib
+  PLATFORM_LIBS=-lshlwapi -lws2_32
+else
+  PLATFORM_DLL_EXT=.so
+  PLATFORM_LIB_EXT=.a
+endif
+
+# Enable MinGW MSVCRT workaround?
+ifeq ($(SIR_MSVCRT_MINGW),1)
+  CFLAGS+=-DSIR_MSVCRT_MINGW
+endif
+
+# Oracle Studio C
+ifneq "$(findstring suncc,$(CC))" ""
+  SUNPRO?=1
+endif
+ifeq ($(SUNPRO),1)
+  CFLAGS+=-fcommon
+  FORTIFY_FLAGS=-U_FORTIFY_SOURCE
+  MMDOPT=-xMMD
+  PTHOPT=-mt=yes
+else
+  FORTIFY_FLAGS=-D_FORTIFY_SOURCE=2
+  MMDOPT=-MMD
+  PTHOPT=-pthread
+endif
+
+# Chibicc and Intel C++ Compiler Classic
+ifneq "$(findstring icc,$(CC))" ""
+  ifneq "$(findstring chibicc,$(CC))" ""
+    FORTIFY_FLAGS=-U_FORTIFY_SOURCE
+    PTHOPT=
+  else
+    INTELC?=1
+  endif
+endif
+ifeq ($(INTELC),1)
+  CFLAGS+=-diag-disable=188
+  CFLAGS+=-diag-disable=191
+  CFLAGS+=-diag-disable=10441
+  CFLAGS+=-diag-disable=10148
+  FORTIFY_FLAGS=-U_FORTIFY_SOURCE
+endif
+
+# NVIDIA HPC SDK C Compiler
+ifneq "$(findstring nvc,$(CC))" ""
+  NVIDIAC?=1
+endif
+ifeq ($(NVIDIAC),1)
+  CFLAGS+=--diag_suppress mixed_enum_type
+  CFLAGS+=--diag_suppress cast_to_qualified_type
+  CFLAGS+=--diag_suppress nonstd_ellipsis_only_param
+endif


### PR DESCRIPTION
* Ensure Makefile has a full dependency graph to avoid unnecessary remakes
* Move platform-specifics toolchain detection stuff into `sirplatform.mk`
* Add flags for Intel C++ Compiler Classic, Chibicc, and NVIDIA HPC SDK C
* Fix installing with `DESTDIR` when using a custom `PREFIX`
* Shrink documentation PNG files using *Advpng*, if available

Closes #87 