### PR TITLE
Add explicit cast; appease Oracle Lint (assignment of double to long may cause implicit narrowing conversion or loss of precision)

### DIFF
--- a/sirinternal.c
+++ b/sirinternal.c
@@ -1093,7 +1093,7 @@ bool _sir_clock_gettime(time_t* tbuf, long* msecbuf) {
 
         if (0 == clock) {
             if (msecbuf)
-                *msecbuf = (ts.tv_nsec / 1e6);
+                *msecbuf = (long)(ts.tv_nsec / 1e6);
         } else {
             if (msecbuf)
                 *msecbuf = 0;


### PR DESCRIPTION
* Add explicit cast; appease Oracle Lint (assignment of double to long may cause implicit narrowing conversion or loss of precision)

Closes #114