### PR TITLE
Leave logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ docs/xml/
 index.md
 
 # test artifacts
+*.log
 logs/*
 
 # annoying macOS files

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ docs/xml/
 index.md
 
 # test artifacts
-*.log
+logs/*
 
 # annoying macOS files
 .DS_Store

--- a/msvs/libsir.vcxproj
+++ b/msvs/libsir.vcxproj
@@ -196,7 +196,6 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\sir.h" />
-    <ClInclude Include="..\sir.hh" />
     <ClInclude Include="..\siransimacros.h" />
     <ClInclude Include="..\sirconfig.h" />
     <ClInclude Include="..\sirconsole.h" />

--- a/msvs/libsir.vcxproj.filters
+++ b/msvs/libsir.vcxproj.filters
@@ -66,9 +66,6 @@
     <ClInclude Include="..\sirconfig.h">
       <Filter>Include</Filter>
     </ClInclude>
-    <ClInclude Include="..\sir.hh">
-      <Filter>Include</Filter>
-    </ClInclude>
     <ClInclude Include="..\sir.h">
       <Filter>Include</Filter>
     </ClInclude>

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -242,7 +242,7 @@ bool sirtest_filecachesanity(void) {
     INIT(si, SIRL_ALL, 0, 0, 0);
     bool pass = si_init;
 
-    size_t numfiles               = SIR_MAXFILES + 1;
+    size_t numfiles             = SIR_MAXFILES + 1;
     sirfileid ids[SIR_MAXFILES] = {0};
 
     sir_options even = SIRO_MSGONLY;
@@ -253,7 +253,7 @@ bool sirtest_filecachesanity(void) {
         snprintf(path, SIR_MAXPATH, "test-%zu.log", n);
         rmfile(path);
         ids[n] = sir_addfile(path, SIRL_ALL, (n % 2) ? odd : even);
-        pass &= NULL != ids[n] && sir_info("test %u", n);
+        pass &= NULL != ids[n] && sir_info("test %zu", n);
     }
 
     pass &= sir_info("test test test");

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -65,6 +65,8 @@
 # define INIT(var, l_stdout, o_stdout, l_stderr, o_stderr) \
     INIT_N(var, l_stdout, o_stdout, l_stderr, o_stderr, "")
 
+# define MAKE_LOG_NAME(name) "logs/" name
+
 # define TEST_S(n) ((n) > 1 ? ("test" "s") : "test")
 # define PRN_STR(str) ((str) ? (str) : RED("NULL"))
 # define PRN_PASS(pass) ((pass) ? GREENB("PASS") : REDB("FAIL"))
@@ -343,11 +345,12 @@ static const struct cl_arg {
     const char* usage;
     const char* desc;
     } _cl_arg_list[] = {
-        {"--perf", "", "Only run the performance measurement test."},
-        {"--wait", "", "Wait for a keypress after running test(s) before exiting."},
-        {"--only", "" ULINE("name") " [, name, ...]", "Only run the test(s) specified."},
-        {"--list", "", "Prints a list of available test names for use with " BOLD("--only") "."},
-        {"--help", "", "Shows this message."}
+        {"--perf",       "", "Only run the performance measurement test."},
+        {"--only",       ""  ULINE("name") " [, name, ...]", "Only run the test(s) specified."},
+        {"--list",       "", "Prints a list of available test names for use with " BOLD("--only") "."},
+        {"--leave-logs", "", "Log files are not deleted so that they may be examined."},
+        {"--wait",       "", "Waits for a keypress after running test(s) before exiting."},
+        {"--help",       "", "Shows this message."}
     };
 
 bool mark_test_to_run(const char* name);


### PR DESCRIPTION
- Using --leave-logs causes log files to not be deleted after the test suite runs
- Logs are now sent to `./logs/` instead of the working directory
- We need to delete `./logs/*` on clean, and if the `logs` dir isn't present on make tests, we need to mkdir it