### PR TITLE
Coverage tweaks and a small test fixup

### DIFF
--- a/.coveralls.sh
+++ b/.coveralls.sh
@@ -176,33 +176,26 @@ remove_sample || true
 run_gcovr run-9.json
 remove_coverage
 
+# Run 10 - Just self-log
+${DO_MAKE:-make} -j ${JOBS:?} clean
+${DO_MAKE:-make} -j ${JOBS:?} SIR_SELFLOG=1
+build/bin/sirexample
+build/bin/sirtests
+remove_sample || true
+run_gcovr run-10.json
+remove_coverage
+
 # Undo redirect
 exec 1>&5
 
 # Process results
 MERGE_MODE="merge-use-line-max"
 gcovr \
-  --add-tracefile run-1.json \
-  --add-tracefile run-2.json \
-  --add-tracefile run-3.json \
-  --add-tracefile run-4.json \
-  --add-tracefile run-5.json \
-  --add-tracefile run-6.json \
-  --add-tracefile run-7.json \
-  --add-tracefile run-8.json \
-  --add-tracefile run-9.json \
+  --add-tracefile "run-*.json" \
   --merge-mode-functions="${MERGE_MODE:?}" \
   --gcov-ignore-parse-errors=negative_hits.warn_once_per_file --html-details coverage-out.html
 gcovr \
-  --add-tracefile run-1.json \
-  --add-tracefile run-2.json \
-  --add-tracefile run-3.json \
-  --add-tracefile run-4.json \
-  --add-tracefile run-5.json \
-  --add-tracefile run-6.json \
-  --add-tracefile run-7.json \
-  --add-tracefile run-8.json \
-  --add-tracefile run-9.json \
+  --add-tracefile "run-*.json" \
   --merge-mode-functions="${MERGE_MODE:?}" \
   --gcov-ignore-parse-errors=negative_hits.warn_once_per_file --coveralls coveralls.json
 

--- a/.coveralls.sh
+++ b/.coveralls.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: Copyright (c) 2018-current Ryan M. Lederman
+
 # Setup for Ubuntu or Debian.
 PATH="/usr/local/bin:/usr/local/sbin:${PATH:-}" && export PATH
 test -n "${NO_APTSETUP:-}" \

--- a/.coveralls.sh
+++ b/.coveralls.sh
@@ -198,11 +198,11 @@ exec 1>&5
 MERGE_MODE="merge-use-line-0"
 gcovr \
   --add-tracefile "run-*.json" \
-  --merge-mode-functions="${MERGE_MODE:?}" \
+  --merge-mode-functions="${MERGE_MODE:?}" -u -s \
   --gcov-ignore-parse-errors=negative_hits.warn_once_per_file --html-details coverage-out.html
 gcovr \
   --add-tracefile "run-*.json" \
-  --merge-mode-functions="${MERGE_MODE:?}" \
+  --merge-mode-functions="${MERGE_MODE:?}" -u \
   --gcov-ignore-parse-errors=negative_hits.warn_once_per_file --coveralls coveralls.json
 
 # Submit results

--- a/.coveralls.sh
+++ b/.coveralls.sh
@@ -44,10 +44,13 @@ cleanup_files()
 cleanup_files
 
 # Make sure we have a token set.
-test -n "${COVERALLS_REPO_TOKEN:-}" \
+test -n "${NO_COVERALLS:-}" \
   || {
-    printf '%s\n' "Error: COVERALLS_REPO_TOKEN is unset."
-    exit 1
+    test -n "${COVERALLS_REPO_TOKEN:-}" \
+      || {
+        printf '%s\n' "Error: COVERALLS_REPO_TOKEN is unset."
+        exit 1
+      }
   }
 
 # Test for command

--- a/.coveralls.sh
+++ b/.coveralls.sh
@@ -189,7 +189,7 @@ remove_coverage
 exec 1>&5
 
 # Process results
-MERGE_MODE="merge-use-line-max"
+MERGE_MODE="merge-use-line-0"
 gcovr \
   --add-tracefile "run-*.json" \
   --merge-mode-functions="${MERGE_MODE:?}" \

--- a/Doxyfile
+++ b/Doxyfile
@@ -51,7 +51,7 @@ PROJECT_NAME           = libsir
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2.2.0
+PROJECT_NUMBER         = 2.2.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ libsir&mdash;a cross-platform, thread-safe logging library
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Copyright (c) 2018-current Ryan M. Lederman <lederman@gmail.com> -->
 
-[![Build Status](https://app.travis-ci.com/aremmell/libsir.svg?branch=master)](https://app.travis-ci.com/aremmell/libsir)&nbsp;![REUSE Compliance](https://img.shields.io/reuse/compliance/github.com%2Faremmell%2Flibsir?label=REUSE3&color=2340b911)&nbsp;![GitHub](https://img.shields.io/github/license/aremmell/libsir?color=%2340b911)&nbsp;[![Codacy Badge](https://app.codacy.com/project/badge/Grade/c631edd919a94bafa21c98dfcf72f2ad)](https://app.codacy.com/gh/aremmell/libsir/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)&nbsp;[![Coverage Status](https://coveralls.io/repos/github/aremmell/libsir/badge.svg)](https://coveralls.io/github/aremmell/libsir)
+[![Build Status](https://app.travis-ci.com/aremmell/libsir.svg?branch=master)](https://app.travis-ci.com/aremmell/libsir)&nbsp;![REUSE Compliance](https://img.shields.io/reuse/compliance/github.com%2Faremmell%2Flibsir?label=REUSE3&color=2340b911)&nbsp;![GitHub](https://img.shields.io/github/license/aremmell/libsir?color=%2340b911)&nbsp;[![Codacy Badge](https://app.codacy.com/project/badge/Grade/c631edd919a94bafa21c98dfcf72f2ad)](https://app.codacy.com/gh/aremmell/libsir/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)&nbsp;[![Coverage Status](https://coveralls.io/repos/github/aremmell/libsir/badge.svg?)](https://coveralls.io/github/aremmell/libsir)
 
 ## <a id="overview" /> Overview
 

--- a/example/example.c
+++ b/example/example.c
@@ -102,7 +102,7 @@ int main(void) {
     /* Pretend to read a config file */
     sir_debug("Config file successfully parsed; connecting to database...");
 
-    /* pretend to connect to a database */
+    /* Pretend to connect to a database */
     sir_debug("Database connection established.");
     sir_debug("Binding a TCP socket to interface '%s'"
               " (IPv4: %s) on port %u and listening for connections...",
@@ -148,15 +148,11 @@ int main(void) {
         report_error(); // GCOVR_EXCL_LINE
 #endif
 
-    /*
-     * Okay, syslog should be configured now. Continue executing.
-     */
+    /* Okay, syslog should be configured now. Continue executing. */
     sir_crit("Database query failure! Ignoring incoming client requests while"
              " the database is analyzed and repaired...");
 
-    /*
-     * Things just keep getting worse for this poor sysadmin.
-     */
+    /* Things just keep getting worse for this poor sysadmin. */
     sir_alert("Database repair attempt unsuccessful! Error: %s", "<unknown>");
     sir_emerg("Unable to process client requests for %s! Restarting...", "4m52s");
 

--- a/example/example.c
+++ b/example/example.c
@@ -54,7 +54,7 @@ int main(void) {
      */
     sirinit si;
     if (!sir_makeinit(&si))
-        return report_error(); // GCOVR_EXCL_LINE
+        return report_error();
 
     /* Levels for stdout: send debug, information, warning, and notice there. */
     si.d_stdout.levels = SIRL_DEBUG | SIRL_INFO | SIRL_WARN | SIRL_NOTICE;
@@ -80,7 +80,7 @@ int main(void) {
 
     /* Initialize libsir. */
     if (!sir_init(&si))
-        return report_error(); // GCOVR_EXCL_LINE
+        return report_error();
 
     /*
      * Configure and add a log file; don't log the process name or hostname,
@@ -88,7 +88,7 @@ int main(void) {
      */
     sirfileid fileid = sir_addfile("libsir-example.log", SIRL_ALL, SIRO_NONAME | SIRO_NOHOST);
     if (0 == fileid)
-        report_error(); // GCOVR_EXCL_LINE
+        report_error();
 
     /*
      * Ready to start logging. The messages passed to sir_debug() will be sent
@@ -139,13 +139,13 @@ int main(void) {
 
 #if !defined(SIR_NO_SYSTEM_LOGGERS)
     if (!sir_syslogid(appname))
-        report_error(); // GCOVR_EXCL_LINE
+        report_error();
 
     if (!sir_syslogopts(SIRO_NOPID))
-        report_error(); // GCOVR_EXCL_LINE
+        report_error();
 
     if (!sir_sysloglevels(SIRL_ERROR | SIRL_CRIT | SIRL_EMERG))
-        report_error(); // GCOVR_EXCL_LINE
+        report_error();
 #endif
 
     /* Okay, syslog should be configured now. Continue executing. */
@@ -161,7 +161,7 @@ int main(void) {
 
     /* Deregister (and close) the log file. */
     if (fileid && !sir_remfile(fileid))
-        report_error(); // GCOVR_EXCL_LINE
+        report_error();
 
     /*
      * Now, you can examine the terminal output, libsir-example.log, and
@@ -179,9 +179,9 @@ int main(void) {
  *
  * @return EXIT_FAILURE
  */
-int report_error(void) { // GCOVR_EXCL_START
+int report_error(void) {
     char message[SIR_MAXERROR] = {0};
     uint16_t code              = sir_geterror(message);
     fprintf(stderr, "libsir error: (%"PRIu16", %s)\n", code, message);
     return EXIT_FAILURE;
-} // GCOVR_EXCL_STOP
+}

--- a/example/example.c
+++ b/example/example.c
@@ -6,7 +6,7 @@
  *
  * @author    Ryan M. Lederman \<lederman@gmail.com\>
  * @date      2018-2023
- * @version   2.2.0
+ * @version   2.2.1
  * @copyright The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/example/example.c
+++ b/example/example.c
@@ -54,7 +54,7 @@ int main(void) {
      */
     sirinit si;
     if (!sir_makeinit(&si))
-        return report_error();
+        return report_error(); // GCOVR_EXCL_LINE
 
     /* Levels for stdout: send debug, information, warning, and notice there. */
     si.d_stdout.levels = SIRL_DEBUG | SIRL_INFO | SIRL_WARN | SIRL_NOTICE;
@@ -80,7 +80,7 @@ int main(void) {
 
     /* Initialize libsir. */
     if (!sir_init(&si))
-        return report_error();
+        return report_error(); // GCOVR_EXCL_LINE
 
     /*
      * Configure and add a log file; don't log the process name or hostname,
@@ -88,7 +88,7 @@ int main(void) {
      */
     sirfileid fileid = sir_addfile("libsir-example.log", SIRL_ALL, SIRO_NONAME | SIRO_NOHOST);
     if (0 == fileid)
-        report_error();
+        report_error(); // GCOVR_EXCL_LINE
 
     /*
      * Ready to start logging. The messages passed to sir_debug() will be sent
@@ -139,13 +139,13 @@ int main(void) {
 
 #if !defined(SIR_NO_SYSTEM_LOGGERS)
     if (!sir_syslogid(appname))
-        report_error();
+        report_error(); // GCOVR_EXCL_LINE
 
     if (!sir_syslogopts(SIRO_NOPID))
-        report_error();
+        report_error(); // GCOVR_EXCL_LINE
 
     if (!sir_sysloglevels(SIRL_ERROR | SIRL_CRIT | SIRL_EMERG))
-        report_error();
+        report_error(); // GCOVR_EXCL_LINE
 #endif
 
     /*
@@ -165,7 +165,7 @@ int main(void) {
 
     /* Deregister (and close) the log file. */
     if (fileid && !sir_remfile(fileid))
-        report_error();
+        report_error(); // GCOVR_EXCL_LINE
 
     /*
      * Now, you can examine the terminal output, libsir-example.log, and
@@ -183,9 +183,9 @@ int main(void) {
  *
  * @return EXIT_FAILURE
  */
-int report_error(void) {
+int report_error(void) { // GCOVR_EXCL_START
     char message[SIR_MAXERROR] = {0};
     uint16_t code              = sir_geterror(message);
     fprintf(stderr, "libsir error: (%"PRIu16", %s)\n", code, message);
     return EXIT_FAILURE;
-}
+} // GCOVR_EXCL_STOP

--- a/include/sir.h
+++ b/include/sir.h
@@ -7,7 +7,7 @@
  *
  * @author    Ryan M. Lederman \<lederman@gmail.com\>
  * @date      2018-2023
- * @version   2.2.0
+ * @version   2.2.1
  * @copyright The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -750,7 +750,7 @@ bool sir_syslogcat(const char* category);
  * **Example:**
  *
  * ~~~
- * 2.2.0-dev
+ * 2.2.1-dev
  * ~~~
  *
  * @return const char* The current libsir version string.

--- a/include/sir/ansimacros.h
+++ b/include/sir/ansimacros.h
@@ -12,7 +12,7 @@
  *
  * @author    Ryan M. Lederman \<lederman@gmail.com\>
  * @date      2018-2023
- * @version   2.2.0
+ * @version   2.2.1
  * @copyright The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/include/sir/config.h
+++ b/include/sir/config.h
@@ -8,7 +8,7 @@
  *
  * @author    Ryan M. Lederman \<lederman@gmail.com\>
  * @date      2018-2023
- * @version   2.2.0
+ * @version   2.2.1
  * @copyright The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/include/sir/console.h
+++ b/include/sir/console.h
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/include/sir/defaults.h
+++ b/include/sir/defaults.h
@@ -7,7 +7,7 @@
  *
  * @author    Ryan M. Lederman \<lederman@gmail.com\>
  * @date      2018-2023
- * @version   2.2.0
+ * @version   2.2.1
  * @copyright The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/include/sir/errors.h
+++ b/include/sir/errors.h
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/include/sir/filecache.h
+++ b/include/sir/filecache.h
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/include/sir/filesystem.h
+++ b/include/sir/filesystem.h
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/include/sir/helpers.h
+++ b/include/sir/helpers.h
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/include/sir/impl.h
+++ b/include/sir/impl.h
@@ -43,7 +43,6 @@ _sir_strlcat(char *dst, const char *src, size_t dsize)
   size_t       dlen;
 
   /* Find the end of dst and adjust bytes left but don't go past end. */
-
   while (n-- != 0 && *dst != '\0')
     dst++;
 

--- a/include/sir/internal.h
+++ b/include/sir/internal.h
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/include/sir/maps.h
+++ b/include/sir/maps.h
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/include/sir/mutex.h
+++ b/include/sir/mutex.h
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/include/sir/platform.h
+++ b/include/sir/platform.h
@@ -57,7 +57,7 @@
 #  if defined(__STDC_NO_ATOMICS__)
 #   undef __HAVE_ATOMIC_H__
 #  else
-#   define __HAVE_ATOMIC_H__
+#   define __HAVE_ATOMIC_H__ /**/
 #  endif
 #  if defined(__GNUC__)
 #   if __GNUC__ <= 4
@@ -96,24 +96,24 @@
 #  endif
 #  define __STDC_WANT_LIB_EXT2__ 1
 #  if defined(__APPLE__) && defined(__MACH__)
-#   define __MACOS__
-#   define _DARWIN_C_SOURCE
+#   define __MACOS__ /**/
+#   define _DARWIN_C_SOURCE /**/
 #  elif defined(__serenity__)
-#   define USE_PTHREAD_GETNAME_NP
+#   define USE_PTHREAD_GETNAME_NP /**/
 #  elif defined(__OpenBSD__)
-#   define __BSD__
+#   define __BSD__ /**/
 #   define __FreeBSD_PTHREAD_NP_11_3__
 #  elif defined(__NetBSD__)
-#   define __BSD__
+#   define __BSD__ /**/
 #   if !defined(_NETBSD_SOURCE)
 #    define _NETBSD_SOURCE 1
 #   endif
-#   define USE_PTHREAD_GETNAME_NP
+#   define USE_PTHREAD_GETNAME_NP /**/
 #  elif defined(__FreeBSD__) || defined(__DragonFly__)
-#   define __BSD__
-#   define _BSD_SOURCE
+#   define __BSD__ /**/
+#   define _BSD_SOURCE /**/
 #   if !defined(_DEFAULT_SOURCE)
-#    define _DEFAULT_SOURCE
+#    define _DEFAULT_SOURCE /**/
 #   endif
 #   include <sys/param.h>
 #   if __FreeBSD_version >= 1202500
@@ -121,15 +121,15 @@
 #   elif __FreeBSD_version >= 1103500
 #    define __FreeBSD_PTHREAD_NP_11_3__
 #   elif __DragonFly_version >= 400907
-#    define __DragonFly_getthreadid__
+#    define __DragonFly_getthreadid__ /**/
 #   endif
 #   if defined(__DragonFly__)
-#    define USE_PTHREAD_GETNAME_NP
+#    define USE_PTHREAD_GETNAME_NP /**/
 #   endif
 #  else
 #   if defined(__HAIKU__)
 #    if !defined(__USE_GNU)
-#     define __USE_GNU
+#     define __USE_GNU /**/
 #    endif
 #    if !defined(_GNU_SOURCE)
 #     define _GNU_SOURCE 1
@@ -139,19 +139,19 @@
 extern /* Workaround a Clang on Haiku bug. */
 int pthread_getname_np(pthread_t thread, char* buffer, size_t length);
 #    endif
-#    define USE_PTHREAD_GETNAME_NP
+#    define USE_PTHREAD_GETNAME_NP /**/
 #   endif
 #   if defined(__linux__)
 #    if !defined(_GNU_SOURCE)
 #     define _GNU_SOURCE 1
 #    endif
-#    define USE_PTHREAD_GETNAME_NP
+#    define USE_PTHREAD_GETNAME_NP /**/
 #   endif
 #   if defined(__CYGWIN__)
 #    if !defined(_GNU_SOURCE)
 #     define _GNU_SOURCE 1
 #    endif
-#    define USE_PTHREAD_GETNAME_NP
+#    define USE_PTHREAD_GETNAME_NP /**/
 #    include <sys/features.h>
 #   endif
 #   if defined(__ANDROID__) && defined(__ANDROID_API__)
@@ -161,36 +161,36 @@ int pthread_getname_np(pthread_t thread, char* buffer, size_t length);
 #   endif
 #   if defined(__illumos__) || ((defined(__sun) || defined(__sun__)) && \
               (defined(__SVR4) || defined(__svr4__)))
-#    define __SOLARIS__
-#    define USE_PTHREAD_GETNAME_NP
+#    define __SOLARIS__ /**/
+#    define USE_PTHREAD_GETNAME_NP /**/
 #    if !defined(_ATFILE_SOURCE)
 #     define _ATFILE_SOURCE 1
 #    endif
 #    if !defined(__EXTENSIONS__)
-#     define __EXTENSIONS__
+#     define __EXTENSIONS__ /**/
 #    endif
 #   endif
 #   if !defined(_POSIX_C_SOURCE)
 #    define _POSIX_C_SOURCE 200809L
 #   endif
 #   if !defined(_DEFAULT_SOURCE)
-#    define _DEFAULT_SOURCE
+#    define _DEFAULT_SOURCE /**/
 #   endif
 #   if !defined(_XOPEN_SOURCE)
 #    define _XOPEN_SOURCE 700
 #   endif
 #  endif
 # else /* _WIN32 */
-#  define __WIN__
-#  define SIR_NO_SYSTEM_LOGGERS
+#  define __WIN__ /**/
+#  define SIR_NO_SYSTEM_LOGGERS /**/
 #  undef __HAVE_ATOMIC_H__
 #  define __WANT_STDC_SECURE_LIB__ 1
 #  define WIN32_LEAN_AND_MEAN
 #  define WINVER       0x0A00 /** Windows 10 SDK */
 #  define _WIN32_WINNT 0x0A00
-#  define _CRT_RAND_S
+#  define _CRT_RAND_S /**/
 #  if defined(__MINGW32__) || defined(__MINGW64__)
-#   define USE_PTHREAD_GETNAME_NP
+#   define USE_PTHREAD_GETNAME_NP /**/
 #  endif
 #  include <windows.h>
 #  include <io.h>
@@ -221,13 +221,13 @@ _set_thread_local_invalid_parameter_handler(
 # if defined(__MINGW64__)
 #  define PID_CAST (int)
 # else
-#  define PID_CAST
+#  define PID_CAST /**/
 # endif
 
 # if defined(_AIX)
 #  define CLOCK_CAST (int)
 # else
-#  define CLOCK_CAST
+#  define CLOCK_CAST /**/
 # endif
 
 # if defined(SIR_ASSERT_ENABLED)
@@ -259,10 +259,10 @@ _set_thread_local_invalid_parameter_handler(
 
 # if !defined(SIR_NO_SYSTEM_LOGGERS)
 #  if defined(__MACOS__) && !defined(__GNUC__)
-#   define SIR_OS_LOG_ENABLED
+#   define SIR_OS_LOG_ENABLED /**/
 #  else
 #   undef SIR_OS_LOG_ENABLED
-#   define SIR_SYSLOG_ENABLED
+#   define SIR_SYSLOG_ENABLED /**/
 #  endif
 # else
 #  undef SIR_OS_LOG_ENABLED
@@ -281,7 +281,7 @@ _set_thread_local_invalid_parameter_handler(
              (defined(__SUNPRO_C) || defined(__SUNPRO_CC))
 #   undef __USE_GNU
 #   include <fcntl.h>
-#   define __USE_GNU
+#   define __USE_GNU /**/
 #  else
 #   include <fcntl.h>
 #  endif
@@ -339,11 +339,11 @@ _set_thread_local_invalid_parameter_handler(
 #  endif
 
 #  if defined(__MACOS__)
-#   define SIR_MSEC_TIMER
-#   define SIR_MSEC_MACH
+#   define SIR_MSEC_TIMER /**/
+#   define SIR_MSEC_MACH /**/
 #  elif _POSIX_TIMERS > 0
-#   define SIR_MSEC_TIMER
-#   define SIR_MSEC_POSIX
+#   define SIR_MSEC_TIMER /**/
+#   define SIR_MSEC_POSIX /**/
 #  else
 #   undef SIR_MSEC_TIMER
 #  endif
@@ -370,8 +370,8 @@ typedef void (*sir_once_fn)(void);
 
 #  define SIR_MAXPATH MAX_PATH
 
-#  define SIR_MSEC_TIMER
-#  define SIR_MSEC_WIN32
+#  define SIR_MSEC_TIMER /**/
+#  define SIR_MSEC_WIN32 /**/
 
 /** The plugin handle type. */
 typedef HMODULE sir_pluginhandle;

--- a/include/sir/platform.h
+++ b/include/sir/platform.h
@@ -34,9 +34,9 @@
 #  define _USE_ATTRIBUTES_FOR_SAL 1
 #  include <sal.h>
 #  define PRINTF_FORMAT _Printf_format_string_
-#  define PRINTF_FORMAT_ATTR(fmt_p, va_p) /**/
+#  define PRINTF_FORMAT_ATTR(fmt_p, va_p)
 # else
-#  define PRINTF_FORMAT /**/
+#  define PRINTF_FORMAT
 #  if defined(__MINGW32__) || defined(__MINGW64__)
 #   if !defined(__USE_MINGW_ANSI_STDIO)
 #    define __USE_MINGW_ANSI_STDIO 1
@@ -48,7 +48,7 @@
 #    define PRINTF_FORMAT_ATTR(fmt_p, va_p) \
      __attribute__((format (printf, fmt_p, va_p)))
 #   else
-#    define PRINTF_FORMAT_ATTR(fmt_p, va_p) /**/
+#    define PRINTF_FORMAT_ATTR(fmt_p, va_p)
 #   endif
 #  endif
 # endif
@@ -57,7 +57,7 @@
 #  if defined(__STDC_NO_ATOMICS__)
 #   undef __HAVE_ATOMIC_H__
 #  else
-#   define __HAVE_ATOMIC_H__ /**/
+#   define __HAVE_ATOMIC_H__
 #  endif
 #  if defined(__GNUC__)
 #   if __GNUC__ <= 4
@@ -96,24 +96,24 @@
 #  endif
 #  define __STDC_WANT_LIB_EXT2__ 1
 #  if defined(__APPLE__) && defined(__MACH__)
-#   define __MACOS__ /**/
-#   define _DARWIN_C_SOURCE /**/
+#   define __MACOS__
+#   define _DARWIN_C_SOURCE
 #  elif defined(__serenity__)
-#   define USE_PTHREAD_GETNAME_NP /**/
+#   define USE_PTHREAD_GETNAME_NP
 #  elif defined(__OpenBSD__)
-#   define __BSD__ /**/
+#   define __BSD__
 #   define __FreeBSD_PTHREAD_NP_11_3__
 #  elif defined(__NetBSD__)
-#   define __BSD__ /**/
+#   define __BSD__
 #   if !defined(_NETBSD_SOURCE)
 #    define _NETBSD_SOURCE 1
 #   endif
-#   define USE_PTHREAD_GETNAME_NP /**/
+#   define USE_PTHREAD_GETNAME_NP
 #  elif defined(__FreeBSD__) || defined(__DragonFly__)
-#   define __BSD__ /**/
-#   define _BSD_SOURCE /**/
+#   define __BSD__
+#   define _BSD_SOURCE
 #   if !defined(_DEFAULT_SOURCE)
-#    define _DEFAULT_SOURCE /**/
+#    define _DEFAULT_SOURCE
 #   endif
 #   include <sys/param.h>
 #   if __FreeBSD_version >= 1202500
@@ -121,15 +121,15 @@
 #   elif __FreeBSD_version >= 1103500
 #    define __FreeBSD_PTHREAD_NP_11_3__
 #   elif __DragonFly_version >= 400907
-#    define __DragonFly_getthreadid__ /**/
+#    define __DragonFly_getthreadid__
 #   endif
 #   if defined(__DragonFly__)
-#    define USE_PTHREAD_GETNAME_NP /**/
+#    define USE_PTHREAD_GETNAME_NP
 #   endif
 #  else
 #   if defined(__HAIKU__)
 #    if !defined(__USE_GNU)
-#     define __USE_GNU /**/
+#     define __USE_GNU
 #    endif
 #    if !defined(_GNU_SOURCE)
 #     define _GNU_SOURCE 1
@@ -139,19 +139,19 @@
 extern /* Workaround a Clang on Haiku bug. */
 int pthread_getname_np(pthread_t thread, char* buffer, size_t length);
 #    endif
-#    define USE_PTHREAD_GETNAME_NP /**/
+#    define USE_PTHREAD_GETNAME_NP
 #   endif
 #   if defined(__linux__)
 #    if !defined(_GNU_SOURCE)
 #     define _GNU_SOURCE 1
 #    endif
-#    define USE_PTHREAD_GETNAME_NP /**/
+#    define USE_PTHREAD_GETNAME_NP
 #   endif
 #   if defined(__CYGWIN__)
 #    if !defined(_GNU_SOURCE)
 #     define _GNU_SOURCE 1
 #    endif
-#    define USE_PTHREAD_GETNAME_NP /**/
+#    define USE_PTHREAD_GETNAME_NP
 #    include <sys/features.h>
 #   endif
 #   if defined(__ANDROID__) && defined(__ANDROID_API__)
@@ -161,36 +161,36 @@ int pthread_getname_np(pthread_t thread, char* buffer, size_t length);
 #   endif
 #   if defined(__illumos__) || ((defined(__sun) || defined(__sun__)) && \
               (defined(__SVR4) || defined(__svr4__)))
-#    define __SOLARIS__ /**/
-#    define USE_PTHREAD_GETNAME_NP /**/
+#    define __SOLARIS__
+#    define USE_PTHREAD_GETNAME_NP
 #    if !defined(_ATFILE_SOURCE)
 #     define _ATFILE_SOURCE 1
 #    endif
 #    if !defined(__EXTENSIONS__)
-#     define __EXTENSIONS__ /**/
+#     define __EXTENSIONS__
 #    endif
 #   endif
 #   if !defined(_POSIX_C_SOURCE)
 #    define _POSIX_C_SOURCE 200809L
 #   endif
 #   if !defined(_DEFAULT_SOURCE)
-#    define _DEFAULT_SOURCE /**/
+#    define _DEFAULT_SOURCE
 #   endif
 #   if !defined(_XOPEN_SOURCE)
 #    define _XOPEN_SOURCE 700
 #   endif
 #  endif
 # else /* _WIN32 */
-#  define __WIN__ /**/
-#  define SIR_NO_SYSTEM_LOGGERS /**/
+#  define __WIN__
+#  define SIR_NO_SYSTEM_LOGGERS
 #  undef __HAVE_ATOMIC_H__
 #  define __WANT_STDC_SECURE_LIB__ 1
 #  define WIN32_LEAN_AND_MEAN
 #  define WINVER       0x0A00 /** Windows 10 SDK */
 #  define _WIN32_WINNT 0x0A00
-#  define _CRT_RAND_S /**/
+#  define _CRT_RAND_S
 #  if defined(__MINGW32__) || defined(__MINGW64__)
-#   define USE_PTHREAD_GETNAME_NP /**/
+#   define USE_PTHREAD_GETNAME_NP
 #  endif
 #  include <windows.h>
 #  include <io.h>
@@ -221,13 +221,13 @@ _set_thread_local_invalid_parameter_handler(
 # if defined(__MINGW64__)
 #  define PID_CAST (int)
 # else
-#  define PID_CAST /**/
+#  define PID_CAST
 # endif
 
 # if defined(_AIX)
 #  define CLOCK_CAST (int)
 # else
-#  define CLOCK_CAST /**/
+#  define CLOCK_CAST
 # endif
 
 # if defined(SIR_ASSERT_ENABLED)
@@ -259,10 +259,10 @@ _set_thread_local_invalid_parameter_handler(
 
 # if !defined(SIR_NO_SYSTEM_LOGGERS)
 #  if defined(__MACOS__) && !defined(__GNUC__)
-#   define SIR_OS_LOG_ENABLED /**/
+#   define SIR_OS_LOG_ENABLED
 #  else
 #   undef SIR_OS_LOG_ENABLED
-#   define SIR_SYSLOG_ENABLED /**/
+#   define SIR_SYSLOG_ENABLED
 #  endif
 # else
 #  undef SIR_OS_LOG_ENABLED
@@ -281,7 +281,7 @@ _set_thread_local_invalid_parameter_handler(
              (defined(__SUNPRO_C) || defined(__SUNPRO_CC))
 #   undef __USE_GNU
 #   include <fcntl.h>
-#   define __USE_GNU /**/
+#   define __USE_GNU
 #  else
 #   include <fcntl.h>
 #  endif
@@ -339,11 +339,11 @@ _set_thread_local_invalid_parameter_handler(
 #  endif
 
 #  if defined(__MACOS__)
-#   define SIR_MSEC_TIMER /**/
-#   define SIR_MSEC_MACH /**/
+#   define SIR_MSEC_TIMER
+#   define SIR_MSEC_MACH
 #  elif _POSIX_TIMERS > 0
-#   define SIR_MSEC_TIMER /**/
-#   define SIR_MSEC_POSIX /**/
+#   define SIR_MSEC_TIMER
+#   define SIR_MSEC_POSIX
 #  else
 #   undef SIR_MSEC_TIMER
 #  endif
@@ -370,8 +370,8 @@ typedef void (*sir_once_fn)(void);
 
 #  define SIR_MAXPATH MAX_PATH
 
-#  define SIR_MSEC_TIMER /**/
-#  define SIR_MSEC_WIN32 /**/
+#  define SIR_MSEC_TIMER
+#  define SIR_MSEC_WIN32
 
 /** The plugin handle type. */
 typedef HMODULE sir_pluginhandle;

--- a/include/sir/platform.h
+++ b/include/sir/platform.h
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/include/sir/plugins.h
+++ b/include/sir/plugins.h
@@ -49,4 +49,5 @@ bool _sir_plugin_cache_rem(sir_plugincache* spc, sirpluginid id);
 bool _sir_plugin_cache_destroy(sir_plugincache* spc);
 bool _sir_plugin_cache_dispatch(sir_plugincache* spc, sir_level level, sirbuf* buf,
     size_t* dispatched, size_t* wanted);
+
 #endif // !_SIR_PLUGINS_H_INCLUDED

--- a/include/sir/plugins.h
+++ b/include/sir/plugins.h
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/include/sir/textstyle.h
+++ b/include/sir/textstyle.h
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/include/sir/types.h
+++ b/include/sir/types.h
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/include/sir/version.h
+++ b/include/sir/version.h
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/plugins/dummy/plugin_dummy.c
+++ b/plugins/dummy/plugin_dummy.c
@@ -94,11 +94,11 @@ PLUGIN_EXPORT bool sir_plugin_query(sir_plugininfo* info) {
 #if !defined(PLUGINDUMMY_BADBEHAVIOR4)
 PLUGIN_EXPORT bool sir_plugin_init(void) {
     printf("\t" DGRAY("plugin_dummy ('%s')") "\n", __func__);
-#if defined(PLUGINDUMMY_BADBEHAVIOR5)
+# if defined(PLUGINDUMMY_BADBEHAVIOR5)
     return false;
-#else
+# else
     return true;
-#endif
+# endif
 }
 #endif
 

--- a/plugins/dummy/plugin_dummy.c
+++ b/plugins/dummy/plugin_dummy.c
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/plugins/dummy/plugin_dummy.h
+++ b/plugins/dummy/plugin_dummy.h
@@ -33,7 +33,7 @@
 BOOL APIENTRY DllMain(HMODULE module, DWORD ul_reason_for_call, LPVOID reserved);
 #  define PLUGIN_EXPORT __declspec(dllexport)
 # else
-#  define PLUGIN_EXPORT
+#  define PLUGIN_EXPORT /**/
 # endif
 
 PLUGIN_EXPORT bool sir_plugin_query(sir_plugininfo* info);

--- a/plugins/dummy/plugin_dummy.h
+++ b/plugins/dummy/plugin_dummy.h
@@ -33,7 +33,7 @@
 BOOL APIENTRY DllMain(HMODULE module, DWORD ul_reason_for_call, LPVOID reserved);
 #  define PLUGIN_EXPORT __declspec(dllexport)
 # else
-#  define PLUGIN_EXPORT /**/
+#  define PLUGIN_EXPORT
 # endif
 
 PLUGIN_EXPORT bool sir_plugin_query(sir_plugininfo* info);

--- a/plugins/dummy/plugin_dummy.h
+++ b/plugins/dummy/plugin_dummy.h
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/plugins/dummy_bad1/plugin_dummy_bad.c
+++ b/plugins/dummy_bad1/plugin_dummy_bad.c
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/plugins/dummy_bad1/plugin_dummy_bad.h
+++ b/plugins/dummy_bad1/plugin_dummy_bad.h
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/plugins/dummy_bad2/plugin_dummy_bad.c
+++ b/plugins/dummy_bad2/plugin_dummy_bad.c
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/plugins/dummy_bad2/plugin_dummy_bad.h
+++ b/plugins/dummy_bad2/plugin_dummy_bad.h
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/plugins/dummy_bad3/plugin_dummy_bad.c
+++ b/plugins/dummy_bad3/plugin_dummy_bad.c
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/plugins/dummy_bad3/plugin_dummy_bad.h
+++ b/plugins/dummy_bad3/plugin_dummy_bad.h
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/plugins/dummy_bad4/plugin_dummy_bad.c
+++ b/plugins/dummy_bad4/plugin_dummy_bad.c
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/plugins/dummy_bad4/plugin_dummy_bad.h
+++ b/plugins/dummy_bad4/plugin_dummy_bad.h
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/plugins/dummy_bad5/plugin_dummy_bad.c
+++ b/plugins/dummy_bad5/plugin_dummy_bad.c
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/plugins/dummy_bad5/plugin_dummy_bad.h
+++ b/plugins/dummy_bad5/plugin_dummy_bad.h
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/plugins/dummy_bad6/plugin_dummy_bad.c
+++ b/plugins/dummy_bad6/plugin_dummy_bad.c
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/plugins/dummy_bad6/plugin_dummy_bad.h
+++ b/plugins/dummy_bad6/plugin_dummy_bad.h
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/plugins/sample/plugin_sample.c
+++ b/plugins/sample/plugin_sample.c
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/plugins/sample/plugin_sample.h
+++ b/plugins/sample/plugin_sample.h
@@ -39,7 +39,7 @@
 BOOL APIENTRY DllMain(HMODULE module, DWORD ul_reason_for_call, LPVOID reserved);
 #  define PLUGIN_EXPORT __declspec(dllexport) /**< Windows-only export keyword. */
 # else
-#  define PLUGIN_EXPORT
+#  define PLUGIN_EXPORT /**/
 # endif
 
 /**

--- a/plugins/sample/plugin_sample.h
+++ b/plugins/sample/plugin_sample.h
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/plugins/sample/plugin_sample.h
+++ b/plugins/sample/plugin_sample.h
@@ -39,7 +39,7 @@
 BOOL APIENTRY DllMain(HMODULE module, DWORD ul_reason_for_call, LPVOID reserved);
 #  define PLUGIN_EXPORT __declspec(dllexport) /**< Windows-only export keyword. */
 # else
-#  define PLUGIN_EXPORT /**/
+#  define PLUGIN_EXPORT
 # endif
 
 /**

--- a/src/sir.c
+++ b/src/sir.c
@@ -7,7 +7,7 @@
  *
  * @author    Ryan M. Lederman \<lederman@gmail.com\>
  * @date      2018-2023
- * @version   2.2.0
+ * @version   2.2.1
  * @copyright The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/src/sirconsole.c
+++ b/src/sirconsole.c
@@ -29,9 +29,9 @@
 #if !defined(__WIN__)
 bool _sir_write_stdio(FILE* stream, const char* message) {
     if (EOF == fputs(message, stream)) {
-        _sir_handleerr(errno); // GCOVR_EXCL_START
+        _sir_handleerr(errno);
         return false;
-    } // GCOVR_EXCL_STOP
+    }
 
     return true;
 }

--- a/src/sirconsole.c
+++ b/src/sirconsole.c
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/src/sirconsole.c
+++ b/src/sirconsole.c
@@ -29,9 +29,9 @@
 #if !defined(__WIN__)
 bool _sir_write_stdio(FILE* stream, const char* message) {
     if (EOF == fputs(message, stream)) {
-        _sir_handleerr(errno);
+        _sir_handleerr(errno); // GCOVR_EXCL_START
         return false;
-    }
+    } // GCOVR_EXCL_STOP
 
     return true;
 }

--- a/src/sirerrors.c
+++ b/src/sirerrors.c
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/src/sirerrors.c
+++ b/src/sirerrors.c
@@ -31,16 +31,16 @@
 
 #if defined(__MACOS__) || defined(__BSD__) || \
     (defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200112L && !defined(_GNU_SOURCE)))
-# define __HAVE_XSI_STRERROR_R__
+# define __HAVE_XSI_STRERROR_R__ /**/
 # if defined(__GLIBC__)
 #  if (__GLIBC__ >= 2 && __GLIBC_MINOR__ < 13)
-#   define __HAVE_XSI_STRERROR_R_ERRNO__
+#   define __HAVE_XSI_STRERROR_R_ERRNO__ /**/
 #  endif
 # endif
 #elif defined(_GNU_SOURCE) && defined(__GLIBC__)
-# define __HAVE_GNU_STRERROR_R__
+# define __HAVE_GNU_STRERROR_R__ /**/
 #elif defined(__HAVE_STDC_SECURE_OR_EXT1__)
-# define __HAVE_STRERROR_S__
+# define __HAVE_STRERROR_S__ /**/
 #endif
 
 /** Per-thread error data */

--- a/src/sirerrors.c
+++ b/src/sirerrors.c
@@ -31,16 +31,16 @@
 
 #if defined(__MACOS__) || defined(__BSD__) || \
     (defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200112L && !defined(_GNU_SOURCE)))
-# define __HAVE_XSI_STRERROR_R__ /**/
+# define __HAVE_XSI_STRERROR_R__
 # if defined(__GLIBC__)
 #  if (__GLIBC__ >= 2 && __GLIBC_MINOR__ < 13)
-#   define __HAVE_XSI_STRERROR_R_ERRNO__ /**/
+#   define __HAVE_XSI_STRERROR_R_ERRNO__
 #  endif
 # endif
 #elif defined(_GNU_SOURCE) && defined(__GLIBC__)
-# define __HAVE_GNU_STRERROR_R__ /**/
+# define __HAVE_GNU_STRERROR_R__
 #elif defined(__HAVE_STDC_SECURE_OR_EXT1__)
-# define __HAVE_STRERROR_S__ /**/
+# define __HAVE_STRERROR_S__
 #endif
 
 /** Per-thread error data */

--- a/src/sirfilecache.c
+++ b/src/sirfilecache.c
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/src/sirfilecache.c
+++ b/src/sirfilecache.c
@@ -254,9 +254,9 @@ bool _sirfile_roll(sirfile* sf, char** newpath) {
                         }
 
                         /* if less than one second has elasped since the last roll
-                            * operation, then we'll overwrite the last rolled log file,
-                            * and that = data loss. make sure the target path does not
-                            * already exist. */
+                         * operation, then we'll overwrite the last rolled log file,
+                         * and that = data loss. make sure the target path does not
+                         * already exist. */
                         if (!_sir_pathexists(*newpath, &exists, SIR_PATH_REL_TO_CWD)) {
                             /* failed to determine if the file already exists; it is better
                              * to continue logging to the same file than to possibly overwrite

--- a/src/sirfilesystem.c
+++ b/src/sirfilesystem.c
@@ -170,7 +170,7 @@ char* _sir_getcwd(void) {
 char* _sir_getappfilename(void) {
 #if defined(__linux__) || defined(__NetBSD__) || defined(__SOLARIS__) || \
     defined(__DragonFly__) || defined(__CYGWIN__) || defined(__serenity__)
-# define __READLINK_OS__
+# define __READLINK_OS__ /**/
 # if defined(__linux__) || defined(__CYGWIN__) || defined(__serenity__)
 #  define PROC_SELF "/proc/self/exe"
 # elif defined(__NetBSD__)

--- a/src/sirfilesystem.c
+++ b/src/sirfilesystem.c
@@ -64,10 +64,10 @@ bool _sir_pathgetstat(const char* restrict path, struct stat* restrict st, sir_r
 
         int fd = open(base_path, open_flags);
         if (-1 == fd) {
-            _sir_handleerr(errno);
+            _sir_handleerr(errno); // GCOVR_EXCL_START
             _sir_safefree(&base_path);
             return false;
-        }
+        } // GCOVR_EXCL_STOP
 
         stat_ret = fstatat(fd, path, st, AT_SYMLINK_NOFOLLOW);
         _sir_safeclose(&fd);
@@ -90,9 +90,9 @@ bool _sir_pathgetstat(const char* restrict path, struct stat* restrict st, sir_r
             st->st_size = SIR_STAT_NONEXISTENT;
             return true;
         } else {
-            _sir_handleerr(errno);
+            _sir_handleerr(errno); // GCOVR_EXCL_START
             return false;
-        }
+        } // GCOVR_EXCL_STOP
     }
 
     return true;
@@ -182,9 +182,9 @@ char* _sir_getappfilename(void) {
 # endif
     struct stat st;
     if (-1 == lstat(PROC_SELF, &st)) {
-        _sir_handleerr(errno);
+        _sir_handleerr(errno); // GCOVR_EXCL_START
         return NULL;
-    }
+    } // GCOVR_EXCL_STOP
 
     size_t size = (st.st_size > 0) ? st.st_size + 2 : SIR_MAXPATH;
 #else
@@ -198,10 +198,10 @@ char* _sir_getappfilename(void) {
         _sir_safefree(&buffer);
         buffer = (char*)calloc(size, sizeof(char));
         if (NULL == buffer) {
-            _sir_handleerr(errno);
+            _sir_handleerr(errno); // GCOVR_EXCL_START
             resolved = false;
             break;
-        }
+        } // GCOVR_EXCL_STOP
 
 #if !defined(__WIN__)
 # if defined(__READLINK_OS__)
@@ -210,7 +210,7 @@ char* _sir_getappfilename(void) {
         if (-1 != read && read < (ssize_t)size - 1) {
             resolved = true;
             break;
-        } else if (-1 == read) {
+        } else if (-1 == read) { // GCOVR_EXCL_START
             _sir_handleerr(errno);
             resolved = false;
             break;
@@ -222,7 +222,7 @@ char* _sir_getappfilename(void) {
             _sir_selflog("warning: readlink reported truncation; not using result!");
             resolved = false;
             break;
-        }
+        } // GCOVR_EXCL_STOP
 # elif defined(_AIX)
         if (size <= SIR_MAXPATH) {
             size = size + SIR_MAXPATH + 1;
@@ -322,10 +322,10 @@ char* _sir_getappfilename(void) {
     } while (true);
 
     if (!resolved) {
-        _sir_safefree(&buffer);
+        _sir_safefree(&buffer); // GCOVR_EXCL_START
         _sir_selflog("error: failed to resolve filename!");
         return NULL;
-    }
+    } // GCOVR_EXCL_STOP
 
     return buffer;
 }
@@ -410,11 +410,11 @@ bool _sir_getrelbasepath(const char* restrict path, bool* restrict relative,
         switch (rel_to) {
             case SIR_PATH_REL_TO_APP: *base_path = _sir_getappdir(); break;
             case SIR_PATH_REL_TO_CWD: *base_path = _sir_getcwd(); break;
-            default: _sir_seterror(_SIR_E_INVALID); return false;
+            default: _sir_seterror(_SIR_E_INVALID); return false; // GCOVR_EXCL_LINE
         }
 
         if (!*base_path)
-            return false;
+            return false; // GCOVR_EXCL_LINE
     }
 
     return true;
@@ -576,9 +576,9 @@ bool _sir_deletefile(const char* restrict path) {
 
 #if !defined(__WIN__)
     if (0 != unlink(path)) {
-        _sir_selflog("failed to delete: '%s' (%d)", path, errno);
+        _sir_selflog("failed to delete: '%s' (%d)", path, errno); // GCOVR_EXCL_START
         return false;
-    }
+    } // GCOVR_EXCL_STOP
     return true;
 #else /* __WIN__ */
     if (!DeleteFileA(path)) {

--- a/src/sirfilesystem.c
+++ b/src/sirfilesystem.c
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/src/sirfilesystem.c
+++ b/src/sirfilesystem.c
@@ -90,9 +90,9 @@ bool _sir_pathgetstat(const char* restrict path, struct stat* restrict st, sir_r
             st->st_size = SIR_STAT_NONEXISTENT;
             return true;
         } else {
-            _sir_handleerr(errno); // GCOVR_EXCL_START
+            _sir_handleerr(errno);
             return false;
-        } // GCOVR_EXCL_STOP
+        }
     }
 
     return true;
@@ -170,7 +170,7 @@ char* _sir_getcwd(void) {
 char* _sir_getappfilename(void) {
 #if defined(__linux__) || defined(__NetBSD__) || defined(__SOLARIS__) || \
     defined(__DragonFly__) || defined(__CYGWIN__) || defined(__serenity__)
-# define __READLINK_OS__ /**/
+# define __READLINK_OS__
 # if defined(__linux__) || defined(__CYGWIN__) || defined(__serenity__)
 #  define PROC_SELF "/proc/self/exe"
 # elif defined(__NetBSD__)
@@ -182,9 +182,9 @@ char* _sir_getappfilename(void) {
 # endif
     struct stat st;
     if (-1 == lstat(PROC_SELF, &st)) {
-        _sir_handleerr(errno); // GCOVR_EXCL_START
+        _sir_handleerr(errno);
         return NULL;
-    } // GCOVR_EXCL_STOP
+    }
 
     size_t size = (st.st_size > 0) ? st.st_size + 2 : SIR_MAXPATH;
 #else
@@ -198,10 +198,10 @@ char* _sir_getappfilename(void) {
         _sir_safefree(&buffer);
         buffer = (char*)calloc(size, sizeof(char));
         if (NULL == buffer) {
-            _sir_handleerr(errno); // GCOVR_EXCL_START
+            _sir_handleerr(errno);
             resolved = false;
             break;
-        } // GCOVR_EXCL_STOP
+        }
 
 #if !defined(__WIN__)
 # if defined(__READLINK_OS__)
@@ -210,7 +210,7 @@ char* _sir_getappfilename(void) {
         if (-1 != read && read < (ssize_t)size - 1) {
             resolved = true;
             break;
-        } else if (-1 == read) { // GCOVR_EXCL_START
+        } else if (-1 == read) {
             _sir_handleerr(errno);
             resolved = false;
             break;
@@ -222,7 +222,7 @@ char* _sir_getappfilename(void) {
             _sir_selflog("warning: readlink reported truncation; not using result!");
             resolved = false;
             break;
-        } // GCOVR_EXCL_STOP
+        }
 # elif defined(_AIX)
         if (size <= SIR_MAXPATH) {
             size = size + SIR_MAXPATH + 1;
@@ -322,10 +322,10 @@ char* _sir_getappfilename(void) {
     } while (true);
 
     if (!resolved) {
-        _sir_safefree(&buffer); // GCOVR_EXCL_START
+        _sir_safefree(&buffer);
         _sir_selflog("error: failed to resolve filename!");
         return NULL;
-    } // GCOVR_EXCL_STOP
+    }
 
     return buffer;
 }
@@ -410,11 +410,11 @@ bool _sir_getrelbasepath(const char* restrict path, bool* restrict relative,
         switch (rel_to) {
             case SIR_PATH_REL_TO_APP: *base_path = _sir_getappdir(); break;
             case SIR_PATH_REL_TO_CWD: *base_path = _sir_getcwd(); break;
-            default: _sir_seterror(_SIR_E_INVALID); return false; // GCOVR_EXCL_LINE
+            default: _sir_seterror(_SIR_E_INVALID); return false;
         }
 
         if (!*base_path)
-            return false; // GCOVR_EXCL_LINE
+            return false;
     }
 
     return true;
@@ -576,9 +576,9 @@ bool _sir_deletefile(const char* restrict path) {
 
 #if !defined(__WIN__)
     if (0 != unlink(path)) {
-        _sir_selflog("failed to delete: '%s' (%d)", path, errno); // GCOVR_EXCL_START
+        _sir_selflog("failed to delete: '%s' (%d)", path, errno);
         return false;
-    } // GCOVR_EXCL_STOP
+    }
     return true;
 #else /* __WIN__ */
     if (!DeleteFileA(path)) {

--- a/src/sirhelpers.c
+++ b/src/sirhelpers.c
@@ -270,7 +270,7 @@ int _sir_strncpy(char* restrict dest, size_t destsz, const char* restrict src, s
 #endif
     }
 
-    return -1; // GCOVR_EXCL_LINE
+    return -1;
 }
 
 int _sir_strncat(char* restrict dest, size_t destsz, const char* restrict src, size_t count) {
@@ -291,7 +291,7 @@ int _sir_strncat(char* restrict dest, size_t destsz, const char* restrict src, s
 #endif
     }
 
-    return -1; // GCOVR_EXCL_LINE
+    return -1;
 }
 
 int _sir_fopen(FILE* restrict* restrict streamptr, const char* restrict filename,
@@ -314,7 +314,7 @@ int _sir_fopen(FILE* restrict* restrict streamptr, const char* restrict filename
 #endif
     }
 
-    return -1; // GCOVR_EXCL_LINE
+    return -1;
 }
 
 struct tm* _sir_localtime(const time_t* restrict timer, struct tm* restrict buf) {
@@ -339,15 +339,14 @@ struct tm* _sir_localtime(const time_t* restrict timer, struct tm* restrict buf)
         _SIR_UNUSED(buf);
         struct tm* ret = localtime(timer);
         if (!ret)
-            _sir_handleerr(errno); // GCOVR_EXCL_LINE
+            _sir_handleerr(errno);
         return ret;
 #endif
     }
 
-    return NULL; // GCOVR_EXCL_LINE
+    return NULL;
 }
 
-// GCOVR_EXCL_START
 int _sir_getchar(void) {
 #if defined(__WIN__)
     return _getch();
@@ -379,6 +378,5 @@ int _sir_getchar(void) {
     }
 
     return ch;
-// GCOVR_EXCL_STOP
 #endif
 }

--- a/src/sirhelpers.c
+++ b/src/sirhelpers.c
@@ -196,11 +196,11 @@ bool _sir_validtextcolor(sir_colormode mode, sir_textcolor color) {
             valid = SIRTC_DEFAULT == color || ((color & 0xff000000) == 0);
             break;
         }
-        case SIRCM_INVALID:
+        case SIRCM_INVALID: // GCOVR_EXCL_START
         default:
             valid = false;
             break;
-    }
+    } // GCOVR_EXCL_STOP
 
     if (!valid) {
         _sir_selflog("invalid text color for mode %d %08"PRIx32" (%"PRId32")",
@@ -270,7 +270,7 @@ int _sir_strncpy(char* restrict dest, size_t destsz, const char* restrict src, s
 #endif
     }
 
-    return -1;
+    return -1; // GCOVR_EXCL_LINE
 }
 
 int _sir_strncat(char* restrict dest, size_t destsz, const char* restrict src, size_t count) {
@@ -291,7 +291,7 @@ int _sir_strncat(char* restrict dest, size_t destsz, const char* restrict src, s
 #endif
     }
 
-    return -1;
+    return -1; // GCOVR_EXCL_LINE
 }
 
 int _sir_fopen(FILE* restrict* restrict streamptr, const char* restrict filename,
@@ -314,7 +314,7 @@ int _sir_fopen(FILE* restrict* restrict streamptr, const char* restrict filename
 #endif
     }
 
-    return -1;
+    return -1; // GCOVR_EXCL_LINE
 }
 
 struct tm* _sir_localtime(const time_t* restrict timer, struct tm* restrict buf) {
@@ -347,6 +347,7 @@ struct tm* _sir_localtime(const time_t* restrict timer, struct tm* restrict buf)
     return NULL;
 }
 
+// GCOVR_EXCL_START
 int _sir_getchar(void) {
 #if defined(__WIN__)
     return _getch();
@@ -378,5 +379,6 @@ int _sir_getchar(void) {
     }
 
     return ch;
+// GCOVR_EXCL_STOP
 #endif
 }

--- a/src/sirhelpers.c
+++ b/src/sirhelpers.c
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/src/sirhelpers.c
+++ b/src/sirhelpers.c
@@ -339,12 +339,12 @@ struct tm* _sir_localtime(const time_t* restrict timer, struct tm* restrict buf)
         _SIR_UNUSED(buf);
         struct tm* ret = localtime(timer);
         if (!ret)
-            _sir_handleerr(errno);
+            _sir_handleerr(errno); // GCOVR_EXCL_LINE
         return ret;
 #endif
     }
 
-    return NULL;
+    return NULL; // GCOVR_EXCL_LINE
 }
 
 // GCOVR_EXCL_START

--- a/src/sirinternal.c
+++ b/src/sirinternal.c
@@ -141,7 +141,7 @@ bool _sir_init(sirinit* si) {
 
     /* Store host name and PID. */
     if (!_sir_gethostname(_cfg->state.hostname)) {
-        _sir_selflog("error: failed to get hostname!");
+        _sir_selflog("error: failed to get hostname!"); // GCOVR_EXCL_LINE
     } else {
         time_t now;
         _cfg->state.last_hname_chk = -1 != time(&now) ? now : 1;
@@ -151,7 +151,7 @@ bool _sir_init(sirinit* si) {
 
     if (0 > snprintf(_cfg->state.pidbuf, SIR_MAXPID, SIR_PIDFORMAT,
                      PID_CAST _cfg->state.pid))
-        _sir_handleerr(errno);
+        _sir_handleerr(errno); // GCOVR_EXCL_LINE
 
 #if !defined(SIR_NO_SYSTEM_LOGGERS)
     /* initialize system logger. */
@@ -418,11 +418,13 @@ bool _sir_mapmutexid(sir_mutex_id mid, sir_mutex** m, void** section) {
             tmpm   = &ts_mutex;
             tmpsec = &sir_text_style_section;
             break;
+        // GCOVR_EXCL_START
         default: /* this should never happen. */
             SIR_ASSERT("!invalid mutex id");
             tmpm   = NULL;
             tmpsec = NULL;
             break;
+        // GCOVR_EXCL_STOP
     }
 
     *m = tmpm;
@@ -442,22 +444,22 @@ void _sir_initialize_once(void) {
 
 void _sir_initmutex_cfg_once(void) {
     if (!_sirmutex_create(&cfg_mutex))
-        _sir_selflog("error: failed to create mutex!");
+        _sir_selflog("error: failed to create mutex!"); // GCOVR_EXCL_LINE
 }
 
 void _sir_initmutex_fc_once(void) {
     if (!_sirmutex_create(&fc_mutex))
-        _sir_selflog("error: failed to create mutex!");
+        _sir_selflog("error: failed to create mutex!"); // GCOVR_EXCL_LINE
 }
 
 void _sir_initmutex_pc_once(void) {
     if (!_sirmutex_create(&pc_mutex))
-        _sir_selflog("error: failed to create mutex!");
+        _sir_selflog("error: failed to create mutex!"); // GCOVR_EXCL_LINE
 }
 
 void _sir_initmutex_ts_once(void) {
     if (!_sirmutex_create(&ts_mutex))
-        _sir_selflog("error: failed to create mutex!");
+        _sir_selflog("error: failed to create mutex!"); // GCOVR_EXCL_LINE
 }
 #else /* __WIN__ */
 BOOL CALLBACK _sir_initialize_once(PINIT_ONCE ponce, PVOID param, PVOID* ctx) {
@@ -551,13 +553,13 @@ bool _sir_logv(sir_level level, PRINTF_FORMAT const char* format, va_list args) 
     time_t now = -1;
     if (-1 != time(&now) &&
         (now - _cfg->state.last_hname_chk) > SIR_HNAME_CHK_INTERVAL) { //-V522
-        _sir_selflog("updating hostname...");
+        _sir_selflog("updating hostname..."); // GCOVR_EXCL_START
         if (!_sir_gethostname(_cfg->state.hostname)) {
             _sir_selflog("error: failed to get hostname!");
         } else {
             _cfg->state.last_hname_chk = now;
             _sir_selflog("hostname: '%s'", _cfg->state.hostname);
-        }
+        } // GCOVR_EXCL_STOP
     }
 
     sirconfig cfg;
@@ -607,15 +609,15 @@ bool _sir_logv(sir_level level, PRINTF_FORMAT const char* format, va_list args) 
     pid_t tid = _sir_gettid();
     if (tid != cfg.state.pid) {
         if (!_sir_getthreadname(buf.tid)) {
-            if (0 > snprintf(buf.tid, SIR_MAXPID, SIR_PIDFORMAT, PID_CAST tid))
+            if (0 > snprintf(buf.tid, SIR_MAXPID, SIR_PIDFORMAT, PID_CAST tid)) // GCOVR_EXCL_START
                 _sir_handleerr(errno);
-        }
+        } // GCOVR_EXCL_STOP
     }
 
     if (0 > vsnprintf(buf.message, SIR_MAXMESSAGE, format, args)) {
-        _sir_handleerr(errno);
+        _sir_handleerr(errno); // GCOVR_EXCL_START
         SIR_ASSERT(false);
-    }
+    } // GCOVR_EXCL_STOP
 
     if (!_sir_validstr(buf.message))
         return false;
@@ -662,9 +664,9 @@ bool _sir_logv(sir_level level, PRINTF_FORMAT const char* format, va_list args) 
 
     _cfg = _sir_locksection(SIRMI_CONFIG);
     if (!_cfg) {
-        _sir_seterror(_SIR_E_INTERNAL);
+        _sir_seterror(_SIR_E_INTERNAL); // GCOVR_EXCL_START
         return false;
-    }
+    } // GCOVR_EXCL_STOP
 
     _cfg->state.last.squelch = cfg.state.last.squelch;
 
@@ -832,7 +834,7 @@ const char* _sir_format(bool styling, sir_options opts, sirbuf* buf) {
         return buf->output;
     }
 
-    return NULL;
+    return NULL; // GCOVR_EXCL_LINE
 }
 
 #if !defined(SIR_NO_SYSTEM_LOGGERS)
@@ -944,9 +946,11 @@ bool _sir_syslog_write(sir_level level, const sirbuf* buf, sir_syslog_dest* ctx)
         case SIRL_CRIT:   syslog_level = LOG_CRIT; break;
         case SIRL_ALERT:  syslog_level = LOG_ALERT; break;
         case SIRL_EMERG:  syslog_level = LOG_EMERG; break;
+        // GCOVR_EXCL_START
         default: /* this should never happen. */
             SIR_ASSERT(!"invalid sir_level");
             syslog_level = LOG_DEBUG;
+        // GCOVR_EXCL_STOP
     }
 
     syslog(syslog_level, "%s", buf->message);
@@ -996,9 +1000,9 @@ bool _sir_syslog_updated(sirinit* si, sir_update_config_data* data) {
 
         return init;
     } else {
-        _sir_selflog("BUG: called without 'updated' flag set!");
+        _sir_selflog("BUG: called without 'updated' flag set!"); // GCOVR_EXCL_START
         return false;
-    }
+    } // GCOVR_EXCL_STOP
 }
 
 bool _sir_syslog_close(sir_syslog_dest* ctx) {

--- a/src/sirinternal.c
+++ b/src/sirinternal.c
@@ -141,7 +141,7 @@ bool _sir_init(sirinit* si) {
 
     /* Store host name and PID. */
     if (!_sir_gethostname(_cfg->state.hostname)) {
-        _sir_selflog("error: failed to get hostname!"); // GCOVR_EXCL_LINE
+        _sir_selflog("error: failed to get hostname!");
     } else {
         time_t now;
         _cfg->state.last_hname_chk = -1 != time(&now) ? now : 1;
@@ -151,7 +151,7 @@ bool _sir_init(sirinit* si) {
 
     if (0 > snprintf(_cfg->state.pidbuf, SIR_MAXPID, SIR_PIDFORMAT,
                      PID_CAST _cfg->state.pid))
-        _sir_handleerr(errno); // GCOVR_EXCL_LINE
+        _sir_handleerr(errno);
 
 #if !defined(SIR_NO_SYSTEM_LOGGERS)
     /* initialize system logger. */
@@ -444,22 +444,22 @@ void _sir_initialize_once(void) {
 
 void _sir_initmutex_cfg_once(void) {
     if (!_sirmutex_create(&cfg_mutex))
-        _sir_selflog("error: failed to create mutex!"); // GCOVR_EXCL_LINE
+        _sir_selflog("error: failed to create mutex!");
 }
 
 void _sir_initmutex_fc_once(void) {
     if (!_sirmutex_create(&fc_mutex))
-        _sir_selflog("error: failed to create mutex!"); // GCOVR_EXCL_LINE
+        _sir_selflog("error: failed to create mutex!");
 }
 
 void _sir_initmutex_pc_once(void) {
     if (!_sirmutex_create(&pc_mutex))
-        _sir_selflog("error: failed to create mutex!"); // GCOVR_EXCL_LINE
+        _sir_selflog("error: failed to create mutex!");
 }
 
 void _sir_initmutex_ts_once(void) {
     if (!_sirmutex_create(&ts_mutex))
-        _sir_selflog("error: failed to create mutex!"); // GCOVR_EXCL_LINE
+        _sir_selflog("error: failed to create mutex!");
 }
 #else /* __WIN__ */
 BOOL CALLBACK _sir_initialize_once(PINIT_ONCE ponce, PVOID param, PVOID* ctx) {
@@ -526,9 +526,9 @@ bool _sir_once(sir_once* once, sir_once_fn func) {
 #if !defined(__WIN__)
     int ret = pthread_once(once, func);
     if (0 != ret) {
-        _sir_handleerr(ret); // GCOVR_EXCL_START
+        _sir_handleerr(ret);
         return false;
-    } // GCOVR_EXCL_STOP
+    }
     return true;
 #else /* __WIN__ */
     BOOL ret = InitOnceExecuteOnce(once, func, NULL, NULL);
@@ -553,13 +553,13 @@ bool _sir_logv(sir_level level, PRINTF_FORMAT const char* format, va_list args) 
     time_t now = -1;
     if (-1 != time(&now) &&
         (now - _cfg->state.last_hname_chk) > SIR_HNAME_CHK_INTERVAL) { //-V522
-        _sir_selflog("updating hostname..."); // GCOVR_EXCL_START
+        _sir_selflog("updating hostname...");
         if (!_sir_gethostname(_cfg->state.hostname)) {
             _sir_selflog("error: failed to get hostname!");
         } else {
             _cfg->state.last_hname_chk = now;
             _sir_selflog("hostname: '%s'", _cfg->state.hostname);
-        } // GCOVR_EXCL_STOP
+        }
     }
 
     sirconfig cfg;
@@ -601,7 +601,7 @@ bool _sir_logv(sir_level level, PRINTF_FORMAT const char* format, va_list args) 
         _SIR_UNUSED(fmt);
 
         if (0 > snprintf(buf.msec, SIR_MAXMSEC, SIR_MSECFORMAT, nowmsec))
-            _sir_handleerr(errno); // GCOVR_EXCL_LINE
+            _sir_handleerr(errno);
     }
 
     buf.level = _sir_formattedlevelstr(level);
@@ -609,15 +609,15 @@ bool _sir_logv(sir_level level, PRINTF_FORMAT const char* format, va_list args) 
     pid_t tid = _sir_gettid();
     if (tid != cfg.state.pid) {
         if (!_sir_getthreadname(buf.tid)) {
-            if (0 > snprintf(buf.tid, SIR_MAXPID, SIR_PIDFORMAT, PID_CAST tid)) // GCOVR_EXCL_START
+            if (0 > snprintf(buf.tid, SIR_MAXPID, SIR_PIDFORMAT, PID_CAST tid))
                 _sir_handleerr(errno);
-        } // GCOVR_EXCL_STOP
+        }
     }
 
     if (0 > vsnprintf(buf.message, SIR_MAXMESSAGE, format, args)) {
-        _sir_handleerr(errno); // GCOVR_EXCL_START
+        _sir_handleerr(errno);
         SIR_ASSERT(false);
-    } // GCOVR_EXCL_STOP
+    }
 
     if (!_sir_validstr(buf.message))
         return false;
@@ -651,7 +651,7 @@ bool _sir_logv(sir_level level, PRINTF_FORMAT const char* format, va_list args) 
                 old_threshold, cfg.state.last.threshold, SIR_SQUELCH_BACKOFF_FACTOR);
 
             if (0 > snprintf(buf.message, SIR_MAXMESSAGE, SIR_SQUELCH_MSG_FORMAT, old_threshold))
-                _sir_handleerr(errno); // GCOVR_EXCL_LINE
+                _sir_handleerr(errno);
         } else if (cfg.state.last.squelch) {
             exit_early = true;
         }
@@ -664,9 +664,9 @@ bool _sir_logv(sir_level level, PRINTF_FORMAT const char* format, va_list args) 
 
     _cfg = _sir_locksection(SIRMI_CONFIG);
     if (!_cfg) {
-        _sir_seterror(_SIR_E_INTERNAL); // GCOVR_EXCL_START
+        _sir_seterror(_SIR_E_INTERNAL);
         return false;
-    } // GCOVR_EXCL_STOP
+    }
 
     _cfg->state.last.squelch = cfg.state.last.squelch;
 
@@ -834,7 +834,7 @@ const char* _sir_format(bool styling, sir_options opts, sirbuf* buf) {
         return buf->output;
     }
 
-    return NULL; // GCOVR_EXCL_LINE
+    return NULL;
 }
 
 #if !defined(SIR_NO_SYSTEM_LOGGERS)
@@ -1000,9 +1000,9 @@ bool _sir_syslog_updated(sirinit* si, sir_update_config_data* data) {
 
         return init;
     } else {
-        _sir_selflog("BUG: called without 'updated' flag set!"); // GCOVR_EXCL_START
+        _sir_selflog("BUG: called without 'updated' flag set!");
         return false;
-    } // GCOVR_EXCL_STOP
+    }
 }
 
 bool _sir_syslog_close(sir_syslog_dest* ctx) {
@@ -1102,7 +1102,7 @@ bool _sir_formattime(time_t now, char* buffer, const char* format) {
 
     SIR_ASSERT(0 != fmttime);
     if (0 == fmttime)
-        _sir_selflog("error: strftime failed; format string: '%s'", format); // GCOVR_EXCL_LINE
+        _sir_selflog("error: strftime failed; format string: '%s'", format);
 
     return 0 != fmttime;
 }
@@ -1224,9 +1224,9 @@ bool _sir_getthreadname(char name[SIR_MAXPID]) {
       defined(USE_PTHREAD_GETNAME_NP) || defined(__MACOS__)
     int ret = pthread_getname_np(pthread_self(), name, SIR_MAXPID);
     if (0 != ret) {
-        _sir_handleerr(ret); // GCOVR_EXCL_START
+        _sir_handleerr(ret);
         return false;
-    } // GCOVR_EXCL_STOP
+    }
 # if defined(__HAIKU__)
     if ((strncmp(name, "pthread_func", SIR_MAXPID)) || _sir_validstrnofail(name))
         snprintf(name, SIR_MAXPID, "%ld", (long)get_pthread_thread_id(pthread_self()));
@@ -1247,9 +1247,9 @@ bool _sir_getthreadname(char name[SIR_MAXPID]) {
 bool _sir_gethostname(char name[SIR_MAXHOST]) {
 #if !defined(__WIN__)
     if (-1 == gethostname(name, SIR_MAXHOST - 1)) {
-        _sir_handleerr(errno); // GCOVR_EXCL_START
+        _sir_handleerr(errno);
         return false;
-    } // GCOVR_EXCL_STOP
+    }
     return true;
 #else
     WSADATA wsad = {0};

--- a/src/sirinternal.c
+++ b/src/sirinternal.c
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/src/sirinternal.c
+++ b/src/sirinternal.c
@@ -526,9 +526,9 @@ bool _sir_once(sir_once* once, sir_once_fn func) {
 #if !defined(__WIN__)
     int ret = pthread_once(once, func);
     if (0 != ret) {
-        _sir_handleerr(ret);
+        _sir_handleerr(ret); // GCOVR_EXCL_START
         return false;
-    }
+    } // GCOVR_EXCL_STOP
     return true;
 #else /* __WIN__ */
     BOOL ret = InitOnceExecuteOnce(once, func, NULL, NULL);
@@ -601,7 +601,7 @@ bool _sir_logv(sir_level level, PRINTF_FORMAT const char* format, va_list args) 
         _SIR_UNUSED(fmt);
 
         if (0 > snprintf(buf.msec, SIR_MAXMSEC, SIR_MSECFORMAT, nowmsec))
-            _sir_handleerr(errno);
+            _sir_handleerr(errno); // GCOVR_EXCL_LINE
     }
 
     buf.level = _sir_formattedlevelstr(level);
@@ -651,7 +651,7 @@ bool _sir_logv(sir_level level, PRINTF_FORMAT const char* format, va_list args) 
                 old_threshold, cfg.state.last.threshold, SIR_SQUELCH_BACKOFF_FACTOR);
 
             if (0 > snprintf(buf.message, SIR_MAXMESSAGE, SIR_SQUELCH_MSG_FORMAT, old_threshold))
-                _sir_handleerr(errno);
+                _sir_handleerr(errno); // GCOVR_EXCL_LINE
         } else if (cfg.state.last.squelch) {
             exit_early = true;
         }
@@ -1102,7 +1102,7 @@ bool _sir_formattime(time_t now, char* buffer, const char* format) {
 
     SIR_ASSERT(0 != fmttime);
     if (0 == fmttime)
-        _sir_selflog("error: strftime failed; format string: '%s'", format);
+        _sir_selflog("error: strftime failed; format string: '%s'", format); // GCOVR_EXCL_LINE
 
     return 0 != fmttime;
 }
@@ -1224,9 +1224,9 @@ bool _sir_getthreadname(char name[SIR_MAXPID]) {
       defined(USE_PTHREAD_GETNAME_NP) || defined(__MACOS__)
     int ret = pthread_getname_np(pthread_self(), name, SIR_MAXPID);
     if (0 != ret) {
-        _sir_handleerr(ret);
+        _sir_handleerr(ret); // GCOVR_EXCL_START
         return false;
-    }
+    } // GCOVR_EXCL_STOP
 # if defined(__HAIKU__)
     if ((strncmp(name, "pthread_func", SIR_MAXPID)) || _sir_validstrnofail(name))
         snprintf(name, SIR_MAXPID, "%ld", (long)get_pthread_thread_id(pthread_self()));
@@ -1247,9 +1247,9 @@ bool _sir_getthreadname(char name[SIR_MAXPID]) {
 bool _sir_gethostname(char name[SIR_MAXHOST]) {
 #if !defined(__WIN__)
     if (-1 == gethostname(name, SIR_MAXHOST - 1)) {
-        _sir_handleerr(errno);
+        _sir_handleerr(errno); // GCOVR_EXCL_START
         return false;
-    }
+    } // GCOVR_EXCL_STOP
     return true;
 #else
     WSADATA wsad = {0};

--- a/src/sirmaps.c
+++ b/src/sirmaps.c
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/src/sirmutex.c
+++ b/src/sirmutex.c
@@ -41,32 +41,32 @@ bool _sirmutex_create(sir_mutex* mutex) {
             }
         }
 
-        _sir_handleerr(op);
+        _sir_handleerr(op); // GCOVR_EXCL_LINE
     }
 
-    return false;
+    return false; // GCOVR_EXCL_LINE
 }
 
 bool _sirmutex_lock(sir_mutex* mutex) {
     if (_sir_validptr(mutex)) {
         int op = pthread_mutex_lock(mutex);
         if (0 != op)
-            _sir_handleerr(op);
+            _sir_handleerr(op); // GCOVR_EXCL_LINE
         return 0 == op;
     }
 
-    return false;
+    return false; // GCOVR_EXCL_LINE
 }
 
 bool _sirmutex_unlock(sir_mutex* mutex) {
     if (_sir_validptr(mutex)) {
         int op = pthread_mutex_unlock(mutex);
         if (0 != op)
-            _sir_handleerr(op);
+            _sir_handleerr(op); // GCOVR_EXCL_LINE
         return 0 == op;
     }
 
-    return false;
+    return false; // GCOVR_EXCL_LINE
 }
 #else /* __WIN__ */
 static bool _sirmutex_waitwin32(sir_mutex mutex, DWORD msec);

--- a/src/sirmutex.c
+++ b/src/sirmutex.c
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/src/sirmutex.c
+++ b/src/sirmutex.c
@@ -41,32 +41,32 @@ bool _sirmutex_create(sir_mutex* mutex) {
             }
         }
 
-        _sir_handleerr(op); // GCOVR_EXCL_LINE
+        _sir_handleerr(op);
     }
 
-    return false; // GCOVR_EXCL_LINE
+    return false;
 }
 
 bool _sirmutex_lock(sir_mutex* mutex) {
     if (_sir_validptr(mutex)) {
         int op = pthread_mutex_lock(mutex);
         if (0 != op)
-            _sir_handleerr(op); // GCOVR_EXCL_LINE
+            _sir_handleerr(op);
         return 0 == op;
     }
 
-    return false; // GCOVR_EXCL_LINE
+    return false;
 }
 
 bool _sirmutex_unlock(sir_mutex* mutex) {
     if (_sir_validptr(mutex)) {
         int op = pthread_mutex_unlock(mutex);
         if (0 != op)
-            _sir_handleerr(op); // GCOVR_EXCL_LINE
+            _sir_handleerr(op);
         return 0 == op;
     }
 
-    return false; // GCOVR_EXCL_LINE
+    return false;
 }
 #else /* __WIN__ */
 static bool _sirmutex_waitwin32(sir_mutex mutex, DWORD msec);

--- a/src/sirplugins.c
+++ b/src/sirplugins.c
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  *
  * License:   The MIT License (MIT)
  *

--- a/src/sirplugins.c
+++ b/src/sirplugins.c
@@ -415,6 +415,7 @@ bool _sir_plugin_cache_dispatch(sir_plugincache* spc, sir_level level, sirbuf* b
     return (*dispatched == *wanted);
 }
 #else /* SIR_NO_PLUGINS */
+// GCOVR_EXCL_START
 sirpluginid _sir_plugin_load(const char* path) {
     _SIR_UNUSED(path);
     return 0;
@@ -495,4 +496,5 @@ bool _sir_plugin_cache_dispatch(sir_plugincache* spc, sir_level level, sirbuf* b
     _SIR_UNUSED(wanted);
     return false;
 }
+// GCOVR_EXCL_STOP
 #endif

--- a/src/sirplugins.c
+++ b/src/sirplugins.c
@@ -415,7 +415,6 @@ bool _sir_plugin_cache_dispatch(sir_plugincache* spc, sir_level level, sirbuf* b
     return (*dispatched == *wanted);
 }
 #else /* SIR_NO_PLUGINS */
-// GCOVR_EXCL_START
 sirpluginid _sir_plugin_load(const char* path) {
     _SIR_UNUSED(path);
     return 0;
@@ -496,5 +495,4 @@ bool _sir_plugin_cache_dispatch(sir_plugincache* spc, sir_level level, sirbuf* b
     _SIR_UNUSED(wanted);
     return false;
 }
-// GCOVR_EXCL_STOP
 #endif

--- a/src/sirtextstyle.c
+++ b/src/sirtextstyle.c
@@ -94,9 +94,11 @@ const sir_textstyle* _sir_getdefstyle(sir_level level) {
         case SIRL_NOTICE: return &sir_lvl_notice_def_style;
         case SIRL_INFO:   return &sir_lvl_info_def_style;
         case SIRL_DEBUG:  return &sir_lvl_debug_def_style;
+        // GCOVR_EXCL_START
         default: /* this should never happen. */
             SIR_ASSERT(!"invalid sir_level");
             return &sir_lvl_info_def_style;
+        // GCOVR_EXCL_STOP
     }
 }
 

--- a/src/sirtextstyle.c
+++ b/src/sirtextstyle.c
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -1690,7 +1690,6 @@ bool sirtest_pluginloader(void) {
     sirpluginid id = sir_loadplugin(plugin1);
     pass &= 0 != id;
     pass &= sir_info("welcome, mister plugin.");
-    pass &= sir_warn("you won't see this message.");
 
     /* re-loading the same plugin should fail. */
     printf("\tloading duplicate plugin: '%s'...\n", plugin1);
@@ -1730,21 +1729,21 @@ bool sirtest_pluginloader(void) {
         print_expected_error();
 
     printf("\tloading bad plugin: '%s'...\n", plugin6);
-    badid = sir_loadplugin(plugin5);
+    badid = sir_loadplugin(plugin6);
     pass &= 0 == badid;
 
     if (pass)
         print_expected_error();
 
     printf("\tloading bad plugin: '%s'...\n", plugin7);
-    badid = sir_loadplugin(plugin5);
-    pass &= 0 == badid;
+    badid = sir_loadplugin(plugin7);
+    pass &= 0 != badid;
 
     if (pass)
         print_expected_error();
 
     printf("\tloading nonexistent plugin: '%s'...\n", plugin8);
-    badid = sir_loadplugin(plugin6);
+    badid = sir_loadplugin(plugin8);
     pass &= 0 == badid;
 
     if (pass)

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -977,7 +977,7 @@ bool sirtest_levelssanity(void) {
     /* individual invalid level. */
     sir_level invalid2 = 0x1337;
     pass &= !_sir_validlevel(invalid2);
-    printf(INDENT_ITEM WHITE("indivudal invalid level: %04"PRIx32) "\n", invalid2);
+    printf(INDENT_ITEM WHITE("individual invalid level: %04"PRIx32) "\n", invalid2);
 
     PRINT_PASS(pass, "\t--- invalid values: %s ---\n\n", PRN_PASS(pass));
 
@@ -1690,6 +1690,7 @@ bool sirtest_pluginloader(void) {
     sirpluginid id = sir_loadplugin(plugin1);
     pass &= 0 != id;
     pass &= sir_info("welcome, mister plugin.");
+    pass &= sir_warn("you won't see this message.");
 
     /* re-loading the same plugin should fail. */
     printf("\tloading duplicate plugin: '%s'...\n", plugin1);

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -66,10 +66,10 @@ int main(int argc, char** argv) {
 #endif
 #if !defined(__WIN__) && !defined(__HAIKU__)
     /* Disallow execution by root / sudo; some of the tests rely on lack of permissions. */
-    if (geteuid() == 0) {
+    if (geteuid() == 0) { // GCOVR_EXCL_START
         fprintf(stderr, "Sorry, but this program may not be executed by root.\n");
         return EXIT_FAILURE;
-    }
+    } // GCOVR_EXCL_STOP
 #else /* __WIN__ */
 # if defined(_DEBUG) && defined(SIR_ASSERT_ENABLED)
     /* Prevents assert() from calling abort() before the user is able to:
@@ -92,14 +92,14 @@ int main(int argc, char** argv) {
         } else if (_sir_strsame(argv[n], _cl_arg_list[1].flag,
             strnlen(argv[n], SIR_MAXCLIFLAG))) { /* --only */
             while (++n < argc) {
-                if (_sir_validstrnofail(argv[n])) {
+                if (_sir_validstrnofail(argv[n])) { // GCOVR_EXCL_START
                     if (*argv[n] == '-' || !mark_test_to_run(argv[n])) {
                         fprintf(stderr, RED("invalid argument: '%s'") "\n", argv[n]);
                         print_usage_info();
                         return EXIT_FAILURE;
                     }
                     to_run++;
-                }
+                } // GCOVR_EXCL_STOP
             };
             if (0 == to_run) {
                 fprintf(stderr, RED("value expected for '%s'") "\n",
@@ -107,17 +107,17 @@ int main(int argc, char** argv) {
                 print_usage_info();
                 return EXIT_FAILURE;
             }
-            only = true;
+            only = true; // GCOVR_EXCL_LINE
         } else if (_sir_strsame(argv[n], _cl_arg_list[2].flag,
             strnlen(argv[n], SIR_MAXCLIFLAG))) { /* --list */
             print_test_list();
             return EXIT_SUCCESS;
         } else if (_sir_strsame(argv[n], _cl_arg_list[3].flag,
             strnlen(argv[n], SIR_MAXCLIFLAG))) { /* --leave-logs */
-            leave_logs = true;
+            leave_logs = true; // GCOVR_EXCL_LINE
         } else if (_sir_strsame(argv[n], _cl_arg_list[4].flag,
             strnlen(argv[n], SIR_MAXCLIFLAG))) { /* --wait */
-            wait = true;
+            wait = true; // GCOVR_EXCL_LINE
         }  else if (_sir_strsame(argv[n], _cl_arg_list[5].flag,
             strnlen(argv[n], SIR_MAXCLIFLAG))) { /* --version */
             print_libsir_version();
@@ -169,7 +169,7 @@ int main(int argc, char** argv) {
                    GREENB("%s%zu " ULINE("libsir") " %s passed in %.03fsec!") "\n\n",
             tgt_tests > 1 ? "all " : "", tgt_tests, TEST_S(tgt_tests), elapsed / 1e3);
     } else {
-        printf("\n" WHITEB("done: ")
+        printf("\n" WHITEB("done: ") // GCOVR_EXCL_START
                    REDB("%zu of %zu " ULINE("libsir") " %s failed in %.03fsec") "\n\n",
             tgt_tests - passed, tgt_tests, TEST_S(tgt_tests), elapsed / 1e3);
 
@@ -179,13 +179,13 @@ int main(int argc, char** argv) {
             if (!sir_tests[t].pass)
                 printf(RED(INDENT_ITEM "%s\n"), sir_tests[t].name);
         printf("\n");
-    }
+    } // GCOVR_EXCL_STOP
 
-    if (wait) {
+    if (wait) { // GCOVR_EXCL_START
         printf(WHITEB(EMPH("press any key to exit...")) "\n");
         int ch = _sir_getchar();
         _SIR_UNUSED(ch);
-    }
+    } // GCOVR_EXCL_STOP
 
     return passed == tgt_tests ? EXIT_SUCCESS : EXIT_FAILURE;
 }
@@ -481,16 +481,16 @@ bool sirtest_rollandarchivefile(void) {
     }
 
     if (0 != fseek(f, fillsize, SEEK_SET)) {
-        handle_os_error(true, "fseek in file %s failed!", logfilename);
+        handle_os_error(true, "fseek in file %s failed!", logfilename); // GCOVR_EXCL_START
         fclose(f);
         return false;
-    }
+    } // GCOVR_EXCL_STOP
 
     if (EOF == fputc('\0', f)) {
-        handle_os_error(true, "fputc in file %s failed!", logfilename);
+        handle_os_error(true, "fputc in file %s failed!", logfilename); // GCOVR_EXCL_START
         fclose(f);
         return false;
-    }
+    } // GCOVR_EXCL_STOP
 
     fclose(f);
 
@@ -1980,11 +1980,11 @@ bool print_test_error(bool result, bool expected) {
     return result;
 }
 
-void print_os_error(void) {
+void print_os_error(void) { // GCOVR_EXCL_START
     char message[SIR_MAXERROR] = {0};
     uint16_t code              = sir_geterror(message);
     fprintf(stderr, "\t" RED("OS error: (%"PRIu16", %s)") "\n", code, message);
-}
+} // GCOVR_EXCL_STOP
 
 bool filter_error(bool pass, uint16_t err) {
     if (!pass) {
@@ -2109,7 +2109,7 @@ bool sirtimerstart(sir_timer* timer) {
 #if !defined(__WIN__)
     int gettime = clock_gettime(SIRTEST_CLOCK, &timer->ts);
     if (0 != gettime) {
-        handle_os_error(true, "clock_gettime(%d) failed!", CLOCK_CAST SIRTEST_CLOCK);
+        handle_os_error(true, "clock_gettime(%d) failed!", CLOCK_CAST SIRTEST_CLOCK); // GCOVR_EXCL_LINE
     }
 
     return 0 == gettime;
@@ -2126,7 +2126,7 @@ float sirtimerelapsed(const sir_timer* timer) {
         return (float)((now.tv_sec * 1e3) + (now.tv_nsec / 1e6) - (timer->ts.tv_sec * 1e3) +
             (timer->ts.tv_nsec / 1e6));
     } else {
-        handle_os_error(true, "clock_gettime(%d) failed!", CLOCK_CAST SIRTEST_CLOCK);
+        handle_os_error(true, "clock_gettime(%d) failed!", CLOCK_CAST SIRTEST_CLOCK); // GCOVR_EXCL_LINE
     }
     return 0.0f;
 #else /* __WIN__ */
@@ -2149,7 +2149,7 @@ long sirtimergetres(void) {
     if (0 == clock_getres(SIRTEST_CLOCK, &res)) {
         retval = res.tv_nsec;
     } else {
-        handle_os_error(true, "clock_getres(%d) failed!", CLOCK_CAST SIRTEST_CLOCK);
+        handle_os_error(true, "clock_getres(%d) failed!", CLOCK_CAST SIRTEST_CLOCK); // GCOVR_EXCL_LINE
     }
 #else /* __WIN__ */
     retval = 100;
@@ -2200,7 +2200,7 @@ bool mark_test_to_run(const char* name) {
     }
 
     if (!found)
-        _sir_selflog("warning: unable to locate '%s' in test array", name);
+        _sir_selflog("warning: unable to locate '%s' in test array", name); // GCOVR_EXCL_LINE
 
     return found;
 }

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -92,14 +92,14 @@ int main(int argc, char** argv) {
         } else if (_sir_strsame(argv[n], _cl_arg_list[1].flag,
             strnlen(argv[n], SIR_MAXCLIFLAG))) { /* --only */
             while (++n < argc) {
-                if (_sir_validstrnofail(argv[n])) { // GCOVR_EXCL_START
+                if (_sir_validstrnofail(argv[n])) {
                     if (*argv[n] == '-' || !mark_test_to_run(argv[n])) {
                         fprintf(stderr, RED("invalid argument: '%s'") "\n", argv[n]);
                         print_usage_info();
                         return EXIT_FAILURE;
                     }
                     to_run++;
-                } // GCOVR_EXCL_STOP
+                }
             };
             if (0 == to_run) {
                 fprintf(stderr, RED("value expected for '%s'") "\n",
@@ -107,17 +107,17 @@ int main(int argc, char** argv) {
                 print_usage_info();
                 return EXIT_FAILURE;
             }
-            only = true; // GCOVR_EXCL_LINE
+            only = true;
         } else if (_sir_strsame(argv[n], _cl_arg_list[2].flag,
             strnlen(argv[n], SIR_MAXCLIFLAG))) { /* --list */
             print_test_list();
             return EXIT_SUCCESS;
         } else if (_sir_strsame(argv[n], _cl_arg_list[3].flag,
             strnlen(argv[n], SIR_MAXCLIFLAG))) { /* --leave-logs */
-            leave_logs = true; // GCOVR_EXCL_LINE
+            leave_logs = true;
         } else if (_sir_strsame(argv[n], _cl_arg_list[4].flag,
             strnlen(argv[n], SIR_MAXCLIFLAG))) { /* --wait */
-            wait = true; // GCOVR_EXCL_LINE
+            wait = true;
         }  else if (_sir_strsame(argv[n], _cl_arg_list[5].flag,
             strnlen(argv[n], SIR_MAXCLIFLAG))) { /* --version */
             print_libsir_version();
@@ -169,7 +169,7 @@ int main(int argc, char** argv) {
                    GREENB("%s%zu " ULINE("libsir") " %s passed in %.03fsec!") "\n\n",
             tgt_tests > 1 ? "all " : "", tgt_tests, TEST_S(tgt_tests), elapsed / 1e3);
     } else {
-        printf("\n" WHITEB("done: ") // GCOVR_EXCL_START
+        printf("\n" WHITEB("done: ")
                    REDB("%zu of %zu " ULINE("libsir") " %s failed in %.03fsec") "\n\n",
             tgt_tests - passed, tgt_tests, TEST_S(tgt_tests), elapsed / 1e3);
 
@@ -179,13 +179,13 @@ int main(int argc, char** argv) {
             if (!sir_tests[t].pass)
                 printf(RED(INDENT_ITEM "%s\n"), sir_tests[t].name);
         printf("\n");
-    } // GCOVR_EXCL_STOP
+    }
 
-    if (wait) { // GCOVR_EXCL_START
+    if (wait) {
         printf(WHITEB(EMPH("press any key to exit...")) "\n");
         int ch = _sir_getchar();
         _SIR_UNUSED(ch);
-    } // GCOVR_EXCL_STOP
+    }
 
     return passed == tgt_tests ? EXIT_SUCCESS : EXIT_FAILURE;
 }
@@ -481,16 +481,16 @@ bool sirtest_rollandarchivefile(void) {
     }
 
     if (0 != fseek(f, fillsize, SEEK_SET)) {
-        handle_os_error(true, "fseek in file %s failed!", logfilename); // GCOVR_EXCL_START
+        handle_os_error(true, "fseek in file %s failed!", logfilename);
         fclose(f);
         return false;
-    } // GCOVR_EXCL_STOP
+    }
 
     if (EOF == fputc('\0', f)) {
-        handle_os_error(true, "fputc in file %s failed!", logfilename); // GCOVR_EXCL_START
+        handle_os_error(true, "fputc in file %s failed!", logfilename);
         fclose(f);
         return false;
-    } // GCOVR_EXCL_STOP
+    }
 
     fclose(f);
 
@@ -1981,13 +1981,11 @@ bool print_test_error(bool result, bool expected) {
     return result;
 }
 
-// GCOVR_EXCL_START
 void print_os_error(void) {
     char message[SIR_MAXERROR] = {0};
     uint16_t code              = sir_geterror(message);
     fprintf(stderr, "\t" RED("OS error: (%"PRIu16", %s)") "\n", code, message);
 }
-// GCOVR_EXCL_STOP
 
 bool filter_error(bool pass, uint16_t err) {
     if (!pass) {

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -1184,7 +1184,7 @@ static bool generic_syslog_test(const char* sl_name, const char* identity, const
 
     for (int i = 0; i < runs; i++) {
         /* randomly skip setting process name, identity/category to thoroughly
-           test fallback routines; randomly update the config mid-run. */
+         * test fallback routines; randomly update the config mid-run. */
         bool set_procname = getrand_bool((uint32_t)sirtimerelapsed(&timer));
         bool set_identity = getrand_bool((uint32_t)sirtimerelapsed(&timer));
         bool set_category = getrand_bool((uint32_t)sirtimerelapsed(&timer));

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -1980,11 +1980,13 @@ bool print_test_error(bool result, bool expected) {
     return result;
 }
 
-void print_os_error(void) { // GCOVR_EXCL_START
+// GCOVR_EXCL_START
+void print_os_error(void) {
     char message[SIR_MAXERROR] = {0};
     uint16_t code              = sir_geterror(message);
     fprintf(stderr, "\t" RED("OS error: (%"PRIu16", %s)") "\n", code, message);
-} // GCOVR_EXCL_STOP
+}
+// GCOVR_EXCL_STOP
 
 bool filter_error(bool pass, uint16_t err) {
     if (!pass) {

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -3,7 +3,7 @@
  *
  * Author:    Ryan M. Lederman <lederman@gmail.com>
  * Copyright: Copyright (c) 2018-2023
- * Version:   2.2.0
+ * Version:   2.2.1
  * License:   The MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
* Fix a bug in the plugin-loader test.
* Add some coverage exclusions where test coverage is impossible or requires user interactivity.
* Adding missing SPDX headers in `.coveralls.sh`
* Consistently use null comment on empty preprocessor definitions.
* Bump some version numbers for 2.2.1-dev