### PR TITLE
Fix for building with legacy IBM XL C/C++ for AIX V16

### DIFF
--- a/sirplatform.mk
+++ b/sirplatform.mk
@@ -111,7 +111,7 @@ ifneq "$(findstring powerpc-ibm-aix7,$(CC))" ""
 endif
 ifeq ($(IBMXLC),1)
   NO_DEFAULT_CFLAGS=1
-  CFLAGS+=-O3 -I. -I.. -qtls -qthreaded -qinfo=mt -qformat=all -qpic=small
+  CFLAGS+=-O3 -Iinclude -qtls -qthreaded -qinfo=mt -qformat=all -qpic=small
   SIR_SHARED=-qmkshrobj
   MMDOPT=
   PTHOPT=


### PR DESCRIPTION
* Regression caused during reorganization of the tree; only affects the legacy compiler