### PR TITLE
Enable platform-specific (OpenBSD, Solaris, illumos) malloc options in the test suite.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ LIBS = $(PTHOPT)
 
 # for test rig and example:
 # link with static library, not shared
-LDFLAGS += $(LIBS) -L$(LIBDIR) -lsir_s $(PLATFORM_LIBS) $(LIBDL)
+LDFLAGS += $(LIBS) -L$(LIBDIR) -lsir_s $(PLATFORM_LIBS) $(LIBDL) $(EXTRA_LIBS)
 
 # translation units
 TUS := $(wildcard src/*.c)

--- a/sirplatform.mk
+++ b/sirplatform.mk
@@ -51,6 +51,21 @@ ifeq ($(NETBSD),1)
   LIBDL=
 endif
 
+# SunOS
+ifneq "$(findstring SunOS,$(UNAME_S))" ""
+  UNAME_O:=$(shell uname -o 2> /dev/null)
+  ifneq "$(findstring Solaris,$(UNAME_O))" ""
+    SUNSYSV?=1
+  endif
+  ifneq "$(findstring illumos,$(UNAME_O))" ""
+    SUNSYSV?=1
+  endif
+endif
+ifeq ($(SUNSYSV),1)
+  CFLAGS+=-DMTMALLOC
+  EXTRA_LIBS+=-lmtmalloc
+endif
+
 # Enable MinGW MSVCRT workaround?
 ifeq ($(SIR_MSVCRT_MINGW),1)
   CFLAGS+=-DSIR_MSVCRT_MINGW

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -62,9 +62,26 @@ static sir_test sir_tests[] = {
 bool leave_logs = false;
 
 int main(int argc, char** argv) {
-#if defined(__HAIKU__) && defined(NDEBUG)
+#if defined(__HAIKU__) && !defined(DEBUG)
     disable_debugger(1);
 #endif
+
+# if defined(MTMALLOC)
+#  include <mtmalloc.h>
+#  if !defined(DEBUG)
+mallocctl(MTDOUBLEFREE, 0);
+#  else
+mallocctl(MTDOUBLEFREE, 1);
+mallocctl(MTINITBUFFER, 1);
+mallocctl(MTDEBUGPATTERN, 1);
+#  endif
+# endif
+
+# if defined(__OpenBSD__) && defined(DEBUG)
+extern char *malloc_options;
+malloc_options = "CFGRSU";
+# endif
+
 #if !defined(__WIN__) && !defined(__HAIKU__)
     /* Disallow execution by root / sudo; some of the tests rely on lack of permissions. */
     if (geteuid() == 0) { // GCOVR_EXCL_START


### PR DESCRIPTION
* The Solaris and illumos options are documented [here](https://docs.oracle.com/cd/E88353_01/html/E37843/mtmalloc-3malloc.html#REFMAN3Amtmalloc-3malloc).
* The OpenBSD options are documented [here](https://man.openbsd.org/malloc).
* `EXTRA_FLAGS` used since the order matters if building statically and the malloc library should always be last.