### PR TITLE
Don't crash if `upper_bound` is `0`

### DIFF
--- a/tests/tests.h
+++ b/tests/tests.h
@@ -343,7 +343,7 @@ uint32_t getrand(uint32_t upper_bound);
 /** Calls getrand() and returns true if even, false if odd. */
 static inline
 bool getrand_bool(uint32_t upper_bound) {
-    return getrand(upper_bound) % 2 == 0;
+    return ((!upper_bound) ? true : getrand(upper_bound) % 2 == 0);
 }
 
 /** prints a message in green if pass is true, or red otherwise. */


### PR DESCRIPTION
* The elapsed time is passed to this function, which can be zero because clock_gettime is used to determine the time elapsed. It's possible for clock_gettime to fail, and if that happens it shouldn't cause the test harness to crash.

![IMG_7932](https://github.com/aremmell/libsir/assets/61629094/b133b88e-2a02-407c-b457-46dbcca29374)