### PR TITLE
Use -g3 for most debug builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ endif
 
 # debug/non-debug CFLAGS
 ifeq ($(SIR_DEBUG),1)
-  CFLAGS += -g -O0 -DDEBUG -U_FORTIFY_SOURCE
+ DBGFLAG ?= -g3
+  CFLAGS += $(DBGFLAG) -O0 -DDEBUG -U_FORTIFY_SOURCE
 else
   CFLAGS += -O3 -DNDEBUG $(FORTIFY_FLAGS)
 endif

--- a/sirplatform.mk
+++ b/sirplatform.mk
@@ -95,6 +95,7 @@ ifneq "$(findstring nvc,$(CC))" ""
   NVIDIAC?=1
 endif
 ifeq ($(NVIDIAC),1)
+  DBGFLAG=-g
   CFLAGS+=--diag_suppress mixed_enum_type
   CFLAGS+=--diag_suppress cast_to_qualified_type
   CFLAGS+=--diag_suppress nonstd_ellipsis_only_param
@@ -102,6 +103,7 @@ endif
 
 # IBM XL C/C++ and GCC for AIX
 ifneq "$(findstring AIX,$(UNAME_S))" ""
+  IBMAIX?=1
   ifneq "$(findstring xlc,$(CC))" ""
     IBMXLC?=1
   endif
@@ -109,14 +111,22 @@ endif
 ifneq "$(findstring powerpc-ibm-aix7,$(CC))" ""
   AIXTLS?=1
 endif
+ifeq ($(IBMAIX),1)
+  DBGFLAG=-g
+endif
 ifeq ($(IBMXLC),1)
   NO_DEFAULT_CFLAGS=1
-  CFLAGS+=-O3 -Iinclude -qtls -qthreaded -qinfo=mt -qformat=all -qpic=small
+  ifeq ($(SIR_DEBUG),1)
+    CFLAGS+=$(DBGFLAG) -O0 -DDEBUG -Iinclude -qtls -qthreaded -qinfo=mt -qformat=all
+  else
+    CFLAGS+=-DNDEBUG -O3 -Iinclude -qtls -qthreaded -qinfo=mt -qformat=all -qpic=small
+  endif
   SIR_SHARED=-qmkshrobj
   MMDOPT=
   PTHOPT=
 endif
 ifeq ($(AIXTLS),1)
+  DBGFLAG=-g
   CFLAGS+=-ftls-model=initial-exec
 endif
 


### PR DESCRIPTION
Use -g3 for most debug builds, except for some OS's and compilers where it's known to be problematic or unsupported.  The user can override the default by setting the DBGFLAG variable in the environment or as an argument to make.

Currently, all compilers on AIX, cross-compilation to AIX, and NVIDIA HPC SDK C (on all operating systems) will keep using `-g` and not `-g3`.

Using `-g3` saves macro definitions for GDB's macro expansion support.