### PR TITLE
Don't include `dlfcn.h` if not building plugins

### DIFF
--- a/include/sir/platform.h
+++ b/include/sir/platform.h
@@ -282,7 +282,9 @@ _set_thread_local_invalid_parameter_handler(
 # define SIR_MAXHOST 256
 
 # if !defined(__WIN__)
-#  include <dlfcn.h>
+#  if !defined(SIR_NO_PLUGINS)
+#   include <dlfcn.h>
+#  endif
 #  include <pthread.h>
 #  if defined(__illumos__)
 #   include <sys/fcntl.h>


### PR DESCRIPTION
Since `dlfcn.h` might not exist (and might be the reason why libsir is being built without plugins); do not include `dlfcn.h` for `SIR_NO_PLUGINS` builds.