### PR TITLE
Avoid undefined behavior and integer overflow

### DIFF
--- a/.coveralls.sh
+++ b/.coveralls.sh
@@ -32,7 +32,6 @@ test -n "${MAKE:-}" && DO_MAKE="${MAKE:-}"
 # Clean-up
 cleanup_files()
 {
-  rm -f ./coveralls       > /dev/null 2>&1
   rm -f ./coverage-out*.* > /dev/null 2>&1
   rm -f ./coveralls.json  > /dev/null 2>&1
 }
@@ -60,10 +59,6 @@ test_for()
 test_for curl
 test_for gcovr
 test_for git
-
-# Get coveralls tool.
-curl -kfsSL https://coveralls.io/coveralls-linux.tar.gz | tar -xz
-chmod a+x ./coveralls
 
 # Setup compiler.
 CC="ccache gcc"
@@ -506,7 +501,7 @@ gcovr \
 
 # Submit results
 test -n "${NO_COVERALLS:-}" || \
-    ./coveralls coveralls.json -r "${COVERALLS_REPO_TOKEN:?}"
+    coveralls coveralls.json -r "${COVERALLS_REPO_TOKEN:?}"
 
 # Cleanup
 test -n "${NO_CLEANUP:-}" \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1440,3 +1440,95 @@ Windows/i686 (Embarcadero):
   interruptible: true
 
 ############################################################################
+
+Clang UBSan:
+  stage: lint
+  needs:
+    - job: Linux/x86_64 (Clang)
+  tags:
+    - Docker-x64
+    - Linux
+  image:
+    name: registry.gitlab.com/libsir/libsir/base:latest
+  script:
+    - *Configuration
+    - export UBSAN_OPTIONS="print_stacktrace=1"
+    - export UBSAN_FLAGS="-fsanitize=undefined,float-divide-by-zero,unsigned-integer-overflow,implicit-conversion,local-bounds,nullability-arg,nullability-assign,nullability-return"
+    - export UBSAN_CFLAGS="${UBSAN_FLAGS:?} -fno-omit-frame-pointer -fno-sanitize-trap -fno-sanitize-recover"
+    - env CC="ccache clang -m32 ${UBSAN_CFLAGS:?}" LDFLAGS="${UBSAN_FLAGS:?} -lubsan" make SIR_DEBUG=1 SIR_SELFLOG=1
+    - ./build/bin/sirtests
+    - make clean
+    - env CC="ccache clang -m64 ${UBSAN_CFLAGS:?}" LDFLAGS="${UBSAN_FLAGS:?} -lubsan" make SIR_DEBUG=1 SIR_SELFLOG=1
+    - ./build/bin/sirtests
+  dependencies: []
+  artifacts:
+    when: always
+    expire_in: 7 days
+    paths:
+      - build/
+      - logs/
+  retry: 2
+  interruptible: true
+
+############################################################################
+
+Clang MSan:
+  stage: lint
+  needs:
+    - job: Linux/x86_64 (Clang)
+  tags:
+    - Docker-x64
+    - Linux
+  image:
+    name: registry.gitlab.com/libsir/libsir/base:latest
+  script:
+    - *Configuration
+    - export MSAN_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=2"
+    - export MSAN_CFLAGS="${MSAN_FLAGS:?} -fno-omit-frame-pointer -fno-sanitize-trap -fno-sanitize-recover"
+    - env CC="ccache clang -m32 ${MSAN_CFLAGS:?}" LDFLAGS="${MSAN_FLAGS:?}" make SIR_DEBUG=1 SIR_SELFLOG=1
+    - ./build/bin/sirtests
+    - make clean
+    - env CC="ccache clang -m64 ${MSAN_CFLAGS:?}" LDFLAGS="${MSAN_FLAGS:?}" make SIR_DEBUG=1 SIR_SELFLOG=1
+    - ./build/bin/sirtests
+  dependencies: []
+  artifacts:
+    when: always
+    expire_in: 7 days
+    paths:
+      - build/
+      - logs/
+  retry: 2
+  interruptible: true
+
+############################################################################
+
+Clang ASan:
+  stage: lint
+  needs:
+    - job: Linux/x86_64 (Clang)
+  tags:
+    - Docker-x64
+    - Linux
+  image:
+    name: registry.gitlab.com/libsir/libsir/base:latest
+  script:
+    - *Configuration
+    - export ASAN_OPTIONS="check_initialization_order=1"
+    - export ASAN_FLAGS="-fsanitize-address -fsanitize-address-use-after-return -fsanitize-address-use-after-scope"
+    - export ASAN_CFLAGS="${ASAN_FLAGS:?} -fno-omit-frame-pointer -fno-sanitize-trap -fno-sanitize-recover"
+    - env CC="ccache clang -m32 ${ASAN_CFLAGS:?}" LDFLAGS="${ASAN_FLAGS:?} -lasan" make SIR_DEBUG=1 SIR_SELFLOG=1
+    - ./build/bin/sirtests
+    - make clean
+    - env CC="ccache clang -m64 ${ASAN_CFLAGS:?}" LDFLAGS="${ASAN_FLAGS:?} -lasan" make SIR_DEBUG=1 SIR_SELFLOG=1
+    - ./build/bin/sirtests
+  dependencies: []
+  artifacts:
+    when: always
+    expire_in: 7 days
+    paths:
+      - build/
+      - logs/
+  retry: 2
+  interruptible: true
+
+############################################################################

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1627,7 +1627,7 @@ Clang Sanitizer (Address 64-bit):
   interruptible: true
 
 ############################################################################
-#
+
 Clang Sanitizer (Address 32-bit):
   stage: lint
   needs:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1516,10 +1516,10 @@ Clang ASan:
     - export ASAN_OPTIONS="check_initialization_order=1"
     - export ASAN_FLAGS="-fsanitize=address -fsanitize-address-use-after-scope"
     - export ASAN_CFLAGS="${ASAN_FLAGS:?} -fno-omit-frame-pointer -fno-sanitize-trap -fno-sanitize-recover"
-    - env CC="ccache clang -m32 ${ASAN_CFLAGS:?}" LDFLAGS="${ASAN_FLAGS:?} -lasan" make SIR_DEBUG=1 SIR_SELFLOG=1
+    - env CC="ccache clang -m32 ${ASAN_CFLAGS:?}" LDFLAGS="${ASAN_FLAGS:?}" make SIR_DEBUG=1 SIR_SELFLOG=1
     - ./build/bin/sirtests
     - make clean
-    - env CC="ccache clang -m64 ${ASAN_CFLAGS:?}" LDFLAGS="${ASAN_FLAGS:?} -lasan" make SIR_DEBUG=1 SIR_SELFLOG=1
+    - env CC="ccache clang -m64 ${ASAN_CFLAGS:?}" LDFLAGS="${ASAN_FLAGS:?}" make SIR_DEBUG=1 SIR_SELFLOG=1
     - ./build/bin/sirtests
   dependencies: []
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1441,7 +1441,7 @@ Windows/i686 (Embarcadero):
 
 ############################################################################
 
-Clang Sanitizer (UBSan):
+Clang Sanitizer (UB 32-bit):
   stage: lint
   needs:
     - job: Linux/x86_64 (Clang)
@@ -1465,10 +1465,35 @@ Clang Sanitizer (UBSan):
       echo -e "section_start:`date +%s`:Test32_section[collapsed=true]\r\e[0K\033[0;36mTest 32-bit ...\033[0m" || true
     - ./build/bin/sirtests
     - echo -e "section_end:`date +%s`:Test32_section\r\e[0K" || true
+  dependencies: []
+  artifacts:
+    when: always
+    expire_in: 7 days
+    paths:
+      - build/
+      - logs/
+  retry: 2
+  interruptible: true
+
+############################################################################
+
+Clang Sanitizer (UB 64-bit):
+  stage: lint
+  needs:
+    - job: Linux/x86_64 (Clang)
+  tags:
+    - Docker-x64
+    - Linux
+  image:
+    name: registry.gitlab.com/libsir/libsir/base:latest
+  script:
+    - *Configuration
+    - export UBSAN_OPTIONS="print_stacktrace=1"
+    - export UBSAN_FLAGS="-fsanitize=undefined,float-divide-by-zero,unsigned-integer-overflow,implicit-conversion,local-bounds,nullability-arg,nullability-assign,nullability-return"
+    - export UBSAN_CFLAGS="${UBSAN_FLAGS:?} -fno-omit-frame-pointer -fno-sanitize-trap -fno-sanitize-recover"
     - |
       # Build ...
       echo -e "section_start:`date +%s`:Build64_section[collapsed=true]\r\e[0K\033[0;36mBuild 64-bit ...\033[0m" || true
-    - make clean
     - env CC="ccache clang -m64 ${UBSAN_CFLAGS:?}" LDFLAGS="${UBSAN_FLAGS:?} -lubsan" make SIR_DEBUG=1 SIR_SELFLOG=1
     - echo -e "section_end:`date +%s`:Build64_section\r\e[0K" || true
     - |
@@ -1488,7 +1513,7 @@ Clang Sanitizer (UBSan):
 
 ############################################################################
 
-Clang Sanitizer (MSan):
+Clang Sanitizer (Memory):
   stage: lint
   needs:
     - job: Linux/x86_64 (Clang)
@@ -1523,7 +1548,43 @@ Clang Sanitizer (MSan):
 
 ############################################################################
 
-Clang Sanitizer (ASan):
+Clang Sanitizer (Address 64-bit):
+  stage: lint
+  needs:
+    - job: Linux/x86_64 (Clang)
+  tags:
+    - Docker-x64
+    - Linux
+  image:
+    name: registry.gitlab.com/libsir/libsir/base:latest
+  script:
+    - *Configuration
+    - export ASAN_OPTIONS="check_initialization_order=1"
+    - export ASAN_FLAGS="-fsanitize=address -fsanitize-address-use-after-scope"
+    - export ASAN_CFLAGS="${ASAN_FLAGS:?} -fno-omit-frame-pointer -fno-sanitize-trap -fno-sanitize-recover"
+    - |
+      # Build ...
+      echo -e "section_start:`date +%s`:Build64_section[collapsed=true]\r\e[0K\033[0;36mBuild 64-bit ...\033[0m" || true
+    - env CC="ccache clang -m64 ${ASAN_CFLAGS:?}" LDFLAGS="${ASAN_FLAGS:?}" make SIR_DEBUG=1 SIR_SELFLOG=1
+    - echo -e "section_end:`date +%s`:Build64_section\r\e[0K" || true
+    - |
+      # Test ...
+      echo -e "section_start:`date +%s`:Test64_section[collapsed=true]\r\e[0K\033[0;36mTest 64-bit ...\033[0m" || true
+    - ./build/bin/sirtests
+    - echo -e "section_end:`date +%s`:Test64_section\r\e[0K" || true
+  dependencies: []
+  artifacts:
+    when: always
+    expire_in: 7 days
+    paths:
+      - build/
+      - logs/
+  retry: 2
+  interruptible: true
+
+############################################################################
+#
+Clang Sanitizer (Address 32-bit):
   stage: lint
   needs:
     - job: Linux/x86_64 (Clang)
@@ -1547,17 +1608,6 @@ Clang Sanitizer (ASan):
       echo -e "section_start:`date +%s`:Test32_section[collapsed=true]\r\e[0K\033[0;36mTest 32-bit ...\033[0m" || true
     - ./build/bin/sirtests
     - echo -e "section_end:`date +%s`:Test32_section\r\e[0K" || true
-    - |
-      # Build ...
-      echo -e "section_start:`date +%s`:Build64_section[collapsed=true]\r\e[0K\033[0;36mBuild 64-bit ...\033[0m" || true
-    - make clean
-    - env CC="ccache clang -m64 ${ASAN_CFLAGS:?}" LDFLAGS="${ASAN_FLAGS:?}" make SIR_DEBUG=1 SIR_SELFLOG=1
-    - echo -e "section_end:`date +%s`:Build64_section\r\e[0K" || true
-    - |
-      # Test ...
-      echo -e "section_start:`date +%s`:Test64_section[collapsed=true]\r\e[0K\033[0;36mTest 64-bit ...\033[0m" || true
-    - ./build/bin/sirtests
-    - echo -e "section_end:`date +%s`:Test64_section\r\e[0K" || true
   dependencies: []
   artifacts:
     when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -798,6 +798,50 @@ Windows/x64 (MSVC):
 
 ############################################################################
 
+Windows/i686 (MSVC):
+  stage: build
+  tags:
+    - Docker-x64
+    - Linux
+  image:
+    name: registry.gitlab.com/libsir/libsir/msvc:latest
+  script:
+    - *Configuration
+    - PATH="/opt/msvc/bin/x86:${PATH:?}" && export PATH
+    - cl.exe 2>&1 | head -3
+    - |
+      # Build ...
+      echo -e "section_start:`date +%s`:Build_section[collapsed=true]\r\e[0K\033[0;36mBuild ...\033[0m" || true
+    - mkdir -p build/bin
+    - cl.exe src/*.c example/example.c -Iinclude /DSIR_NO_PLUGINS=1 /O2 /W4 /std:c11 /wd4996 /Febuild\\bin\\sirexample.exe
+    - cl.exe src/*.c tests/tests.c -Iinclude /DSIR_NO_PLUGINS=1 /O2 /W4 /std:c11 /wd4996 /Febuild\\bin\\sirtests.exe
+    - echo -e "section_end:`date +%s`:Build_section\r\e[0K" || true
+    - |
+      # Test ...
+      echo -e "section_start:`date +%s`:Test_section[collapsed=true]\r\e[0K\033[0;36mTest ...\033[0m" || true
+    - mkdir -p logs
+    - touch build/bin/file.exists
+    - export WINEDEBUG=-all
+    - screen -mDL sh -c 'wine64 build/bin/sirexample.exe; printf "\n%s\n" "$?"' && tail -1 screenlog.0 | dos2unix -f | ansifilter | grep -E '^0$'
+    - cat screenlog.0
+    - rm -f screenlog.0
+    - screen -mDL sh -c 'wine64 build/bin/sirtests.exe; printf "\n%s\n" "$?"' && tail -1 screenlog.0 | dos2unix -f | ansifilter | grep -E '^0$'
+    - cat screenlog.0
+    - rm -f screenlog.0
+    - echo -e "section_end:`date +%s`:Test_section\r\e[0K" || true
+  dependencies: []
+  artifacts:
+    when: always
+    expire_in: 7 days
+    paths:
+      - build/
+      - logs/
+      - screenlog.0
+  retry: 2
+  interruptible: true
+
+############################################################################
+
 Windows/x64 (MinGW-MSVCRT):
   stage: build
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1485,7 +1485,7 @@ Windows/i686 (Embarcadero):
 
 ############################################################################
 
-Clang Sanitizer (UB 32-bit):
+Clang Sanitizer (UB, 32-bit):
   stage: lint
   needs:
     - job: Linux/x86_64 (Clang)
@@ -1521,7 +1521,7 @@ Clang Sanitizer (UB 32-bit):
 
 ############################################################################
 
-Clang Sanitizer (UB 64-bit):
+Clang Sanitizer (UB, 64-bit):
   stage: lint
   needs:
     - job: Linux/x86_64 (Clang)
@@ -1592,7 +1592,7 @@ Clang Sanitizer (Memory):
 
 ############################################################################
 
-Clang Sanitizer (Address 64-bit):
+Clang Sanitizer (Address, 64-bit):
   stage: lint
   needs:
     - job: Linux/x86_64 (Clang)
@@ -1628,7 +1628,7 @@ Clang Sanitizer (Address 64-bit):
 
 ############################################################################
 
-Clang Sanitizer (Address 32-bit):
+Clang Sanitizer (Address, 32-bit):
   stage: lint
   needs:
     - job: Linux/x86_64 (Clang)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1441,7 +1441,7 @@ Windows/i686 (Embarcadero):
 
 ############################################################################
 
-Clang UBSan:
+Clang Sanitizer (UBSan):
   stage: lint
   needs:
     - job: Linux/x86_64 (Clang)
@@ -1488,7 +1488,7 @@ Clang UBSan:
 
 ############################################################################
 
-Clang MSan:
+Clang Sanitizer (MSan):
   stage: lint
   needs:
     - job: Linux/x86_64 (Clang)
@@ -1523,7 +1523,7 @@ Clang MSan:
 
 ############################################################################
 
-Clang ASan:
+Clang Sanitizer (ASan):
   stage: lint
   needs:
     - job: Linux/x86_64 (Clang)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1455,11 +1455,27 @@ Clang UBSan:
     - export UBSAN_OPTIONS="print_stacktrace=1"
     - export UBSAN_FLAGS="-fsanitize=undefined,float-divide-by-zero,unsigned-integer-overflow,implicit-conversion,local-bounds,nullability-arg,nullability-assign,nullability-return"
     - export UBSAN_CFLAGS="${UBSAN_FLAGS:?} -fno-omit-frame-pointer -fno-sanitize-trap -fno-sanitize-recover"
+    - |
+      # Build ...
+      echo -e "section_start:`date +%s`:Build32_section[collapsed=true]\r\e[0K\033[0;36mBuild 32-bit ...\033[0m" || true
     - env CC="ccache clang -m32 ${UBSAN_CFLAGS:?}" LDFLAGS="${UBSAN_FLAGS:?} -lubsan" make SIR_DEBUG=1 SIR_SELFLOG=1
+    - echo -e "section_end:`date +%s`:Build32_section\r\e[0K" || true
+    - |
+      # Test ...
+      echo -e "section_start:`date +%s`:Test32_section[collapsed=true]\r\e[0K\033[0;36mTest 32-bit ...\033[0m" || true
     - ./build/bin/sirtests
+    - echo -e "section_end:`date +%s`:Test32_section\r\e[0K" || true
+    - |
+      # Build ...
+      echo -e "section_start:`date +%s`:Build64_section[collapsed=true]\r\e[0K\033[0;36mBuild 64-bit ...\033[0m" || true
     - make clean
     - env CC="ccache clang -m64 ${UBSAN_CFLAGS:?}" LDFLAGS="${UBSAN_FLAGS:?} -lubsan" make SIR_DEBUG=1 SIR_SELFLOG=1
+    - echo -e "section_end:`date +%s`:Build64_section\r\e[0K" || true
+    - |
+      # Test ...
+      echo -e "section_start:`date +%s`:Test64_section[collapsed=true]\r\e[0K\033[0;36mTest 64-bit ...\033[0m" || true
     - ./build/bin/sirtests
+    - echo -e "section_end:`date +%s`:Test64_section\r\e[0K" || true
   dependencies: []
   artifacts:
     when: always
@@ -1485,11 +1501,16 @@ Clang MSan:
     - *Configuration
     - export MSAN_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=2"
     - export MSAN_CFLAGS="${MSAN_FLAGS:?} -fno-omit-frame-pointer -fno-sanitize-trap -fno-sanitize-recover"
-    - env CC="ccache clang -m32 ${MSAN_CFLAGS:?}" LDFLAGS="${MSAN_FLAGS:?}" make SIR_DEBUG=1 SIR_SELFLOG=1
-    - ./build/bin/sirtests
-    - make clean
+    - |
+      # Build ...
+      echo -e "section_start:`date +%s`:Build_section[collapsed=true]\r\e[0K\033[0;36mBuild ...\033[0m" || true
     - env CC="ccache clang -m64 ${MSAN_CFLAGS:?}" LDFLAGS="${MSAN_FLAGS:?}" make SIR_DEBUG=1 SIR_SELFLOG=1
+    - echo -e "section_end:`date +%s`:Build_section\r\e[0K" || true
+    - |
+      # Test ...
+      echo -e "section_start:`date +%s`:Test_section[collapsed=true]\r\e[0K\033[0;36mTest ...\033[0m" || true
     - ./build/bin/sirtests
+    - echo -e "section_end:`date +%s`:Test_section\r\e[0K" || true
   dependencies: []
   artifacts:
     when: always
@@ -1516,11 +1537,27 @@ Clang ASan:
     - export ASAN_OPTIONS="check_initialization_order=1"
     - export ASAN_FLAGS="-fsanitize=address -fsanitize-address-use-after-scope"
     - export ASAN_CFLAGS="${ASAN_FLAGS:?} -fno-omit-frame-pointer -fno-sanitize-trap -fno-sanitize-recover"
+    - |
+      # Build ...
+      echo -e "section_start:`date +%s`:Build32_section[collapsed=true]\r\e[0K\033[0;36mBuild 32-bit ...\033[0m" || true
     - env CC="ccache clang -m32 ${ASAN_CFLAGS:?}" LDFLAGS="${ASAN_FLAGS:?}" make SIR_DEBUG=1 SIR_SELFLOG=1
+    - echo -e "section_end:`date +%s`:Build32_section\r\e[0K" || true
+    - |
+      # Test ...
+      echo -e "section_start:`date +%s`:Test32_section[collapsed=true]\r\e[0K\033[0;36mTest 32-bit ...\033[0m" || true
     - ./build/bin/sirtests
+    - echo -e "section_end:`date +%s`:Test32_section\r\e[0K" || true
+    - |
+      # Build ...
+      echo -e "section_start:`date +%s`:Build64_section[collapsed=true]\r\e[0K\033[0;36mBuild 64-bit ...\033[0m" || true
     - make clean
     - env CC="ccache clang -m64 ${ASAN_CFLAGS:?}" LDFLAGS="${ASAN_FLAGS:?}" make SIR_DEBUG=1 SIR_SELFLOG=1
+    - echo -e "section_end:`date +%s`:Build64_section\r\e[0K" || true
+    - |
+      # Test ...
+      echo -e "section_start:`date +%s`:Test64_section[collapsed=true]\r\e[0K\033[0;36mTest 64-bit ...\033[0m" || true
     - ./build/bin/sirtests
+    - echo -e "section_end:`date +%s`:Test64_section\r\e[0K" || true
   dependencies: []
   artifacts:
     when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1514,7 +1514,7 @@ Clang ASan:
   script:
     - *Configuration
     - export ASAN_OPTIONS="check_initialization_order=1"
-    - export ASAN_FLAGS="-fsanitize-address -fsanitize-address-use-after-return -fsanitize-address-use-after-scope"
+    - export ASAN_FLAGS="-fsanitize=address -fsanitize-address-use-after-scope"
     - export ASAN_CFLAGS="${ASAN_FLAGS:?} -fno-omit-frame-pointer -fno-sanitize-trap -fno-sanitize-recover"
     - env CC="ccache clang -m32 ${ASAN_CFLAGS:?}" LDFLAGS="${ASAN_FLAGS:?} -lasan" make SIR_DEBUG=1 SIR_SELFLOG=1
     - ./build/bin/sirtests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1502,7 +1502,7 @@ Clang Sanitizer (UB, 32-bit):
     - |
       # Build ...
       echo -e "section_start:`date +%s`:Build32_section[collapsed=true]\r\e[0K\033[0;36mBuild 32-bit ...\033[0m" || true
-    - env CC="ccache clang -m32 ${UBSAN_CFLAGS:?}" LDFLAGS="${UBSAN_FLAGS:?} -lubsan" make SIR_DEBUG=1 SIR_SELFLOG=1
+    - env CC="ccache clang -m32 ${UBSAN_CFLAGS:?}" LDFLAGS="${UBSAN_FLAGS:?}" make SIR_DEBUG=1 SIR_SELFLOG=1
     - echo -e "section_end:`date +%s`:Build32_section\r\e[0K" || true
     - |
       # Test ...
@@ -1538,7 +1538,7 @@ Clang Sanitizer (UB, 64-bit):
     - |
       # Build ...
       echo -e "section_start:`date +%s`:Build64_section[collapsed=true]\r\e[0K\033[0;36mBuild 64-bit ...\033[0m" || true
-    - env CC="ccache clang -m64 ${UBSAN_CFLAGS:?}" LDFLAGS="${UBSAN_FLAGS:?} -lubsan" make SIR_DEBUG=1 SIR_SELFLOG=1
+    - env CC="ccache clang -m64 ${UBSAN_CFLAGS:?}" LDFLAGS="${UBSAN_FLAGS:?}" make SIR_DEBUG=1 SIR_SELFLOG=1
     - echo -e "section_end:`date +%s`:Build64_section\r\e[0K" || true
     - |
       # Test ...

--- a/.gitlab-ci/base/Dockerfile
+++ b/.gitlab-ci/base/Dockerfile
@@ -52,6 +52,9 @@ RUN \
       gcc \
       gcovr \
       git \
+      glibc-devel \
+      glibc-devel.i686 \
+      glibc-headers-x86 \
       glibc-static \
       global \
       libasan \

--- a/.gitlab-ci/base/Dockerfile
+++ b/.gitlab-ci/base/Dockerfile
@@ -38,7 +38,6 @@ RUN \
       clang-tools-extra \
       cmake \
       compiler-rt \
-      compiler-rt.i686 \
       cppcheck \
       cppcheck-htmlreport \
       cppi \
@@ -53,20 +52,14 @@ RUN \
       gcovr \
       git \
       glibc-devel \
-      glibc-devel.i686 \
       glibc-headers-x86 \
       glibc-static \
       global \
       libasan \
-      libasan.i686 \
       libnsl \
       libnsl2 \
-      libnsl2.i686 \
-      libnsl.i686 \
       libtirpc \
-      libtirpc.i686 \
       libubsan \
-      libubsan.i686 \
       libxml2-devel \
       libxslt-devel \
       lld \
@@ -91,6 +84,18 @@ RUN \
       vim \
       wget \
       zip \
+&& \
+  dnf4 -y --allowerasing --setopt=install_weak_deps=True --setopt=keepcache=True install \
+      compiler-rt.i686 \
+      glibc-devel.i686 \
+      libasan.i686 \
+      libnsl2.i686 \
+      libnsl.i686 \
+      libtirpc.i686 \
+      libubsan.i686 \
+&& \
+  dnf4 -y --allowerasing reinstall \
+      compiler-rt \
 && \
   ( curl -fsSLO https://rpm.nodesource.com/setup_20.x || true ) \
 && \
@@ -207,6 +212,7 @@ RUN \
   rm -rf /tmp/duma-build && \
   ldconfig \
 && \
+  ( dnf4 -y clean > /dev/null 2>&1 ; dnf4 -y clean all > /dev/null 2>&1 ; true ) || true && \
   dnf -y clean all && \
   rm -rf ~/.cache && \
   rm -rf /var/tmp/* && \

--- a/.gitlab-ci/base/Dockerfile
+++ b/.gitlab-ci/base/Dockerfile
@@ -37,6 +37,8 @@ RUN \
       clang-analyzer \
       clang-tools-extra \
       cmake \
+      compiler-rt \
+      compiler-rt.i686 \
       cppcheck \
       cppcheck-htmlreport \
       cppi \
@@ -52,12 +54,16 @@ RUN \
       git \
       glibc-static \
       global \
+      libasan \
+      libasan.i686 \
       libnsl \
       libnsl2 \
       libnsl2.i686 \
       libnsl.i686 \
       libtirpc \
       libtirpc.i686 \
+      libubsan \
+      libubsan.i686 \
       libxml2-devel \
       libxslt-devel \
       lld \

--- a/include/sir/helpers.h
+++ b/include/sir/helpers.h
@@ -325,7 +325,7 @@ bool _sir_getchar(char* input);
  */
 static inline
 uint32_t FNV32_1a(const uint8_t* data, size_t len) {
-    uint32_t hash = 2166136261UL;
+    uint32_t hash = 2166136261U;
     for (size_t n = 0; n < len; n++) {
         hash ^= (uint32_t)data[n];
         hash *= 16777619UL;

--- a/include/sir/helpers.h
+++ b/include/sir/helpers.h
@@ -337,6 +337,9 @@ uint32_t FNV32_1a(const uint8_t* data, size_t len) {
  * Implementation of the 64-bit FNV-1a OWHF (http://isthe.com/chongo/tech/comp/fnv/)
  * watered down to only handle null-terminated strings.
  */
+# if defined(__clang__) /* only Clang has unsigned-integer-overflow */
+SANITIZE_SUPPRESS("unsigned-integer-overflow")
+# endif
 static inline
 uint64_t FNV64_1a(const char* str)
 {

--- a/include/sir/helpers.h
+++ b/include/sir/helpers.h
@@ -328,7 +328,7 @@ uint32_t FNV32_1a(const uint8_t* data, size_t len) {
     uint32_t hash = 2166136261U;
     for (size_t n = 0; n < len; n++) {
         hash ^= (uint32_t)data[n];
-        hash *= 16777619UL;
+        hash = (uint32_t)(hash * 16777619ULL);
     }
     return hash;
 }

--- a/include/sir/helpers.h
+++ b/include/sir/helpers.h
@@ -337,7 +337,7 @@ uint32_t FNV32_1a(const uint8_t* data, size_t len) {
  * Implementation of the 64-bit FNV-1a OWHF (http://isthe.com/chongo/tech/comp/fnv/)
  * watered down to only handle null-terminated strings.
  */
-# if defined(__clang__) /* only Clang has unsigned-integer-overflow */
+# if defined(__clang__) /* only Clang has unsigned-integer-overflow; GCC BZ#96829 */
 SANITIZE_SUPPRESS("unsigned-integer-overflow")
 # endif
 static inline

--- a/include/sir/helpers.h
+++ b/include/sir/helpers.h
@@ -346,7 +346,7 @@ uint64_t FNV64_1a(const char* str)
     uint64_t hash = 14695981039346656037ULL;
     for (const char* c = str; *c; c++) {
         hash ^= (uint64_t)(unsigned char)(*c);
-        hash *= 1099511628211ULL;
+        hash *= 1099511628211ULL; /* unsigned-integer-overflow */
     }
     return hash;
 }

--- a/include/sir/helpers.h
+++ b/include/sir/helpers.h
@@ -325,10 +325,10 @@ bool _sir_getchar(char* input);
  */
 static inline
 uint32_t FNV32_1a(const uint8_t* data, size_t len) {
-    uint32_t hash = 2166136261U;
+    uint32_t hash = 2166136261UL;
     for (size_t n = 0; n < len; n++) {
         hash ^= (uint32_t)data[n];
-        hash *= 16777619U;
+        hash *= 16777619UL;
     }
     return hash;
 }
@@ -340,10 +340,10 @@ uint32_t FNV32_1a(const uint8_t* data, size_t len) {
 static inline
 uint64_t FNV64_1a(const char* str)
 {
-    uint64_t hash = 14695981039346656037UL;
+    uint64_t hash = 14695981039346656037ULL;
     for (const char* c = str; *c; c++) {
         hash ^= (uint64_t)(unsigned char)(*c);
-        hash *= 1099511628211UL;
+        hash *= 1099511628211ULL;
     }
     return hash;
 }

--- a/include/sir/platform.h
+++ b/include/sir/platform.h
@@ -53,13 +53,17 @@
 #  endif
 # endif
 
+# undef HAS_ATTRIBUTE
 # if defined(__has_attribute) && (defined(__clang__) || defined(__GNUC__))
-#  if __has_attribute(no_sanitize)
-#   define SANITIZE_SUPPRESS(str) __attribute__((no_sanitize(str)))
-#  else
-#   define SANITIZE_SUPPRESS(str)
-#  endif
+#  define HAS_ATTRIBUTE(atr) __has_attribute(atr)
 # else
+#  define HAS_ATTRIBUTE(atr) 0
+# endif
+# undef SANITIZE_SUPPRESS
+# if HAS_ATTRIBUTE(no_sanitize)
+#  define SANITIZE_SUPPRESS(str) __attribute__((no_sanitize(str)))
+# endif
+# if !defined(SANITIZE_SUPPRESS)
 #  define SANITIZE_SUPPRESS(str)
 # endif
 

--- a/include/sir/platform.h
+++ b/include/sir/platform.h
@@ -53,6 +53,16 @@
 #  endif
 # endif
 
+# if defined(__has_attribute) && (defined(__clang__) || defined(__GNUC__))
+#  if __has_attribute(no_sanitize)
+#   define SANITIZE_SUPPRESS(str) __attribute__((no_sanitize(str)))
+#  else
+#   define SANITIZE_SUPPRESS(str)
+#  endif
+# else
+#  define SANITIZE_SUPPRESS(str)
+# endif
+
 # if !defined(_WIN32)
 #  if defined(__STDC_NO_ATOMICS__)
 #   undef __HAVE_ATOMIC_H__

--- a/src/sirhelpers.c
+++ b/src/sirhelpers.c
@@ -93,6 +93,9 @@ bool _sir_validfd(int fd) {
 }
 
 /** Validates a sir_update_config_data structure. */
+# if defined(__clang__) /* only Clang has implicit-conversion; GCC BZ#87454 */
+SANITIZE_SUPPRESS("implicit-conversion")
+# endif
 bool _sir_validupdatedata(sir_update_config_data* data) {
     if (!_sir_validptr(data))
         return false;
@@ -151,6 +154,9 @@ bool _sir_validlevel(sir_level level) {
     return _sir_seterror(_SIR_E_LEVELS);
 }
 
+# if defined(__clang__) /* only Clang has implicit-conversion; GCC BZ#87454 */
+SANITIZE_SUPPRESS("implicit-conversion")
+#endif
 bool _sir_validopts(sir_options opts) {
     if ((SIRO_ALL == opts || SIRO_MSGONLY == opts) ||
         ((_sir_bittest(opts, SIRO_NOTIME)          ||

--- a/src/sirhelpers.c
+++ b/src/sirhelpers.c
@@ -93,9 +93,9 @@ bool _sir_validfd(int fd) {
 }
 
 /** Validates a sir_update_config_data structure. */
-# if defined(__clang__) /* only Clang has implicit-conversion; GCC BZ#87454 */
+#if defined(__clang__) /* only Clang has implicit-conversion; GCC BZ#87454 */
 SANITIZE_SUPPRESS("implicit-conversion")
-# endif
+#endif
 bool _sir_validupdatedata(sir_update_config_data* data) {
     if (!_sir_validptr(data))
         return false;
@@ -154,7 +154,7 @@ bool _sir_validlevel(sir_level level) {
     return _sir_seterror(_SIR_E_LEVELS);
 }
 
-# if defined(__clang__) /* only Clang has implicit-conversion; GCC BZ#87454 */
+#if defined(__clang__) /* only Clang has implicit-conversion; GCC BZ#87454 */
 SANITIZE_SUPPRESS("implicit-conversion")
 #endif
 bool _sir_validopts(sir_options opts) {

--- a/src/sirhelpers.c
+++ b/src/sirhelpers.c
@@ -101,7 +101,8 @@ bool _sir_validupdatedata(sir_update_config_data* data) {
         return false;
 
     bool valid = true;
-    if ((data->fields & SIRU_ALL) == 0 || (data->fields & ~SIRU_ALL) != 0)
+    if ((data->fields & SIRU_ALL) == 0 ||
+          (data->fields & ~SIRU_ALL) != 0) /* implicit-conversion */
         valid = false;
 
     if (valid && _sir_bittest(data->fields, SIRU_LEVELS))
@@ -167,7 +168,7 @@ bool _sir_validopts(sir_options opts) {
          _sir_bittest(opts, SIRO_NOPID)            ||
          _sir_bittest(opts, SIRO_NOTID)            ||
          _sir_bittest(opts, SIRO_NOHDR))           &&
-         ((opts & ~(SIRO_MSGONLY | SIRO_NOHDR)) == 0)))
+         ((opts & ~(SIRO_MSGONLY | SIRO_NOHDR)) == 0))) /* implicit-conversion */
          return true;
 
     _sir_selflog("invalid options: %08"PRIx32, opts);

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -831,6 +831,9 @@ bool sirtest_textstylesanity(void) {
     return print_result_and_return(pass);
 }
 
+# if defined(__clang__) /* only Clang has implicit-conversion; GCC BZ#87454 */
+SANITIZE_SUPPRESS("implicit-conversion")
+#endif
 bool sirtest_optionssanity(void) {
     INIT(si, SIRL_ALL, 0, 0, 0);
     bool pass = si_init;
@@ -926,7 +929,7 @@ bool sirtest_optionssanity(void) {
     }
 
     /* greater than SIRO_NOHDR. */
-    invalid = (0xFFFF0000 & ~SIRO_NOHDR);
+    invalid = (0xFFFF0000 & ~SIRO_NOHDR); /* implicit-conversion */
     pass &= !_sir_validopts(invalid);
     printf(INDENT_ITEM WHITE("greater than SIRO_NOHDR: %08"PRIx32) "\n", invalid);
 

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -831,7 +831,7 @@ bool sirtest_textstylesanity(void) {
     return print_result_and_return(pass);
 }
 
-# if defined(__clang__) /* only Clang has implicit-conversion; GCC BZ#87454 */
+#if defined(__clang__) /* only Clang has implicit-conversion; GCC BZ#87454 */
 SANITIZE_SUPPRESS("implicit-conversion")
 #endif
 bool sirtest_optionssanity(void) {

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -787,7 +787,7 @@ bool sirtest_textstylesanity(void) {
     printf("\t" WHITEB("--- change mode: 256-color ---") "\n");
     pass &= sir_setcolormode(SIRCM_256);
 
-    for (sir_textcolor fg = 0, bg = 255; fg < 256; fg++, bg--) {
+    for (sir_textcolor fg = 0, bg = 255; (fg < 256 && bg > 0); fg++, bg--) {
         if (fg != bg) {
             pass &= sir_settextstyle(SIRL_DEBUG, SIRTA_NORMAL, fg, bg);
             pass &= sir_debug("this is 256-color mode (fg: %"PRIu32", bg: %"PRIu32")",


### PR DESCRIPTION
* Avoid undefined behavior and integer overflow
* Add new CI jobs ...
  * Clang Memory Sanitizer
  * Clang Undefined Behavior Sanitizer (32-bit)
  * Clang Undefined Behavior Sanitizer (64-bit)
  * Clang Address Sanitizer (32-bit)
  * Clang Address Sanitizer (64-bit)
  * MSVC i686 (32-bit)