### PR TITLE
Use (and pass) Clang's `-Wmissing-variable-declarations` check and enable in CI

### DIFF
--- a/.lint.sh
+++ b/.lint.sh
@@ -203,6 +203,7 @@ test_extra()
             CFLAGS="-Werror
                     -Wmissing-prototypes
                     -Wdouble-promotion
+                    -Wmissing-variable-declarations
                     -Wconversion
                     -Wno-sign-conversion
                     -Wno-string-conversion"

--- a/plugins/dummy/plugin_dummy.c
+++ b/plugins/dummy/plugin_dummy.c
@@ -58,14 +58,14 @@ BOOL APIENTRY DllMain(HMODULE module, DWORD ul_reason_for_call, LPVOID reserved)
 }
 #endif
 
-const uint8_t maj_ver   = 1;
-const uint8_t min_ver   = 0;
-const uint8_t bld_ver   = 0;
-const sir_levels levels = SIRL_DEBUG | SIRL_INFO;
-const sir_options opts  = SIRO_NOHOST | SIRO_NOTID;
-const char* author      = "libsir contributors";
-const char* desc        = "Logs messages and function calls to stdout.";
-const uint64_t caps     = 0;
+static const uint8_t maj_ver   = 1;
+static const uint8_t min_ver   = 0;
+static const uint8_t bld_ver   = 0;
+static const sir_levels levels = SIRL_DEBUG | SIRL_INFO;
+static const sir_options opts  = SIRO_NOHOST | SIRO_NOTID;
+static const char* author      = "libsir contributors";
+static const char* desc        = "Logs messages and function calls to stdout.";
+static const uint64_t caps     = 0;
 
 PLUGIN_EXPORT bool sir_plugin_query(sir_plugininfo* info) {
 #if defined(PLUGINDUMMY_BADBEHAVIOR2)

--- a/plugins/dummy/plugin_dummy.c
+++ b/plugins/dummy/plugin_dummy.c
@@ -80,7 +80,9 @@ PLUGIN_EXPORT bool sir_plugin_query(sir_plugininfo* info) {
     info->levels    = 0xfe23;
     info->opts      = 0x1234abcd;
     info->author    = NULL;
+    SIR_UNUSED(author);
     info->desc      = "";
+    SIR_UNUSED(desc);
 #else
     info->levels    = levels;
     info->opts      = opts;

--- a/plugins/sample/plugin_sample.c
+++ b/plugins/sample/plugin_sample.c
@@ -37,14 +37,14 @@ BOOL APIENTRY DllMain(HMODULE module, DWORD ul_reason_for_call, LPVOID reserved)
 }
 #endif
 
-const uint8_t maj_ver   = 1;
-const uint8_t min_ver   = 0;
-const uint8_t bld_ver   = 0;
-const sir_levels levels = SIRL_DEBUG | SIRL_INFO;
-const sir_options opts  = SIRO_NOHOST | SIRO_NOTID;
-const char* author      = "libsir contributors";
-const char* desc        = "Logs messages and function calls to stdout.";
-const uint64_t caps     = 0;
+static const uint8_t maj_ver   = 1;
+static const uint8_t min_ver   = 0;
+static const uint8_t bld_ver   = 0;
+static const sir_levels levels = SIRL_DEBUG | SIRL_INFO;
+static const sir_options opts  = SIRO_NOHOST | SIRO_NOTID;
+static const char* author      = "libsir contributors";
+static const char* desc        = "Logs messages and function calls to stdout.";
+static const uint64_t caps     = 0;
 
 PLUGIN_EXPORT bool sir_plugin_query(sir_plugininfo* info) {
     info->iface_ver = SIR_PLUGIN_VCURRENT;

--- a/src/sirtextstyle.c
+++ b/src/sirtextstyle.c
@@ -27,7 +27,7 @@
 #include "sir/internal.h"
 #include "sir/defaults.h"
 
-sir_colormode sir_color_mode = SIRCM_16;
+static sir_colormode sir_color_mode = SIRCM_16;
 
 /** Wrapper around the level-to-style map and the color mode. This is the data
  * structure protected by the SIRMI_TEXTSTYLE mutex. */

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -60,7 +60,7 @@ static sir_test sir_tests[] = {
     {"get-version-info",        sirtest_getversioninfo, false, true}
 };
 
-bool leave_logs = false;
+static bool leave_logs = false;
 
 int main(int argc, char** argv) {
 #if defined(__HAIKU__) && !defined(DEBUG)


### PR DESCRIPTION
* Use (and pass) Clang's `-Wmissing-variable-declarations` check and enable in CI