### PR TITLE
Use (and pass) Clang's `-Wswitch-enum` check and enable in CI

### DIFF
--- a/.lint.sh
+++ b/.lint.sh
@@ -205,6 +205,7 @@ test_extra()
                     -Wdouble-promotion
                     -Wconversion
                     -Wno-sign-conversion
+                    -Wswitch-enum
                     -Wno-string-conversion"
             ${MAKE:-make}
                 -j "${CPUS:-1}" ' | tr '\n' ' ' | tr -s ' ' >> ./.extra.sh

--- a/src/sirinternal.c
+++ b/src/sirinternal.c
@@ -919,7 +919,10 @@ bool _sir_syslog_write(sir_level level, const sirbuf* buf, sir_syslog_dest* ctx)
         case SIRL_ALERT:  syslog_level = LOG_ALERT; break;
         case SIRL_EMERG:  syslog_level = LOG_EMERG; break;
         // GCOVR_EXCL_START
-        default: /* this should never happen. */
+        case SIRL_NONE: /* this should never happen. */
+        case SIRL_ALL:
+        case SIRL_DEFAULT:
+        default:
             SIR_ASSERT(!"invalid sir_level");
             syslog_level = LOG_DEBUG;
         // GCOVR_EXCL_STOP

--- a/src/sirtextstyle.c
+++ b/src/sirtextstyle.c
@@ -97,7 +97,10 @@ const sir_textstyle* _sir_getdefstyle(sir_level level) {
         case SIRL_INFO:   return &sir_lvl_info_def_style;
         case SIRL_DEBUG:  return &sir_lvl_debug_def_style;
         // GCOVR_EXCL_START
-        default: /* this should never happen. */
+        case SIRL_NONE: /* these should never happen */
+        case SIRL_ALL:
+        case SIRL_DEFAULT:
+        default:
             SIR_ASSERT(!"invalid sir_level");
             return &sir_lvl_info_def_style;
         // GCOVR_EXCL_STOP


### PR DESCRIPTION
* Use (and pass) Clang's `-Wswitch-enum` check and enable in CI