### PR TITLE
Use localtime_r for improved performance

### DIFF
--- a/include/sir/config.h
+++ b/include/sir/config.h
@@ -123,7 +123,7 @@
  *   15:13:41 Fri 9 Jun 23 (-0600)
  *   ~~~
  */
-# define SIR_FHTIMEFORMAT "%H:%M:%S %a %d %b %y (%z)"
+# define SIR_FHTIMEFORMAT "%H:%M:%S %a %d %b %Y %Z (%z)"
 
 /**
  * The format string written to a log file when logging begins or the file

--- a/include/sir/config.h
+++ b/include/sir/config.h
@@ -123,7 +123,7 @@
  *   15:13:41 Fri 9 Jun 23 (-0600)
  *   ~~~
  */
-# define SIR_FHTIMEFORMAT "%H:%M:%S %a %d %b %Y %Z (%z)"
+# define SIR_FHTIMEFORMAT "%H:%M:%S %a %d %b %y (%z)"
 
 /**
  * The format string written to a log file when logging begins or the file

--- a/include/sir/platform.h
+++ b/include/sir/platform.h
@@ -202,6 +202,7 @@ int pthread_getname_np(pthread_t thread, char* buffer, size_t length);
 #  endif
 # else /* _WIN32 */
 #  define __WIN__
+#  undef SIR_NO_SYSTEM_LOGGERS
 #  define SIR_NO_SYSTEM_LOGGERS
 #  undef __HAVE_ATOMIC_H__
 #  define __WANT_STDC_SECURE_LIB__ 1

--- a/src/sirhelpers.c
+++ b/src/sirhelpers.c
@@ -323,7 +323,7 @@ struct tm* _sir_localtime(const time_t* restrict timer, struct tm* restrict buf)
         }
 # else
         struct tm* ret = localtime_s(timer, buf);
-        if (0 == ret) {
+        if (!ret) {
             (void)_sir_handleerr(ret);
             return NULL;
         }

--- a/src/sirhelpers.c
+++ b/src/sirhelpers.c
@@ -327,10 +327,10 @@ struct tm* _sir_localtime(const time_t* restrict timer, struct tm* restrict buf)
 
         return buf;
 #else /* !__HAVE_STDC_SECURE_OR_EXT1___ */
-# if defined(__WIN__) && !defined(__EMBARCADEROC__)
-        struct tm* ret = localtime(timer);
-# else
+# if !defined(__WIN__) || defined(__EMBARCADEROC__)
         struct tm* ret = localtime_r(timer, buf);
+# else /* __WIN__ */
+        struct tm* ret = localtime(timer);
 # endif
         if (!ret)
             (void)_sir_handleerr(errno);

--- a/src/sirhelpers.c
+++ b/src/sirhelpers.c
@@ -315,15 +315,15 @@ int _sir_fopen(FILE* restrict* restrict streamptr, const char* restrict filename
 struct tm* _sir_localtime(const time_t* restrict timer, struct tm* restrict buf) {
     if (_sir_validptr(timer) && _sir_validptr(buf)) {
 #if defined(__HAVE_STDC_SECURE_OR_EXT1__) && !defined(__EMBARCADEROC__)
-# if defined(__WIN__)
-        errno_t ret = localtime_s(buf, timer);
-        if (0 != ret) {
-            (void)_sir_handleerr(ret);
-            return NULL;
-        }
-# else
+# if !defined(__WIN__)
         struct tm* ret = localtime_s(timer, buf);
         if (!ret) {
+            (void)_sir_handleerr(errno);
+            return NULL;
+        }
+# else /* __WIN__ */
+        errno_t ret = localtime_s(buf, timer);
+        if (0 != ret) {
             (void)_sir_handleerr(ret);
             return NULL;
         }

--- a/src/sirhelpers.c
+++ b/src/sirhelpers.c
@@ -314,25 +314,24 @@ int _sir_fopen(FILE* restrict* restrict streamptr, const char* restrict filename
 
 struct tm* _sir_localtime(const time_t* restrict timer, struct tm* restrict buf) {
     if (_sir_validptr(timer) && _sir_validptr(buf)) {
-#if defined(__HAVE_STDC_SECURE_OR_EXT1__)
+#if defined(__HAVE_STDC_SECURE_OR_EXT1___)
 # if defined(__WIN__)
         errno_t ret = (errno_t)localtime_s(buf, timer);
+# else
+        errno_t ret = (errno_t)localtime_s(timer, buf);
+# endif
         if (0 != ret) {
             (void)_sir_handleerr(ret);
             return NULL;
         }
 
         return buf;
-# else /* __WIN__ */
-        struct tm* ret = localtime_s(timer, buf);
-        if (!ret)
-            (void)_sir_handleerr(errno);
-
-        return ret;
-# endif
-#else
-        SIR_UNUSED(buf);
+#else /* !__HAVE_STDC_SECURE_OR_EXT1___ */
+# if defined(__WIN__) && !defined(__EMBARCADEROC__)
         struct tm* ret = localtime(timer);
+# else
+        struct tm* ret = localtime_r(timer, buf);
+# endif
         if (!ret)
             (void)_sir_handleerr(errno);
 

--- a/src/sirhelpers.c
+++ b/src/sirhelpers.c
@@ -314,22 +314,26 @@ int _sir_fopen(FILE* restrict* restrict streamptr, const char* restrict filename
 
 struct tm* _sir_localtime(const time_t* restrict timer, struct tm* restrict buf) {
     if (_sir_validptr(timer) && _sir_validptr(buf)) {
-#if defined(__HAVE_STDC_SECURE_OR_EXT1___)
+#if defined(__HAVE_STDC_SECURE_OR_EXT1__) && !defined(__EMBARCADEROC__)
 # if defined(__WIN__)
-        errno_t ret = (errno_t)localtime_s(buf, timer);
-# else
-        errno_t ret = (errno_t)localtime_s(timer, buf);
-# endif
+        errno_t ret = localtime_s(buf, timer);
         if (0 != ret) {
             (void)_sir_handleerr(ret);
             return NULL;
         }
+# else
+        struct tm* ret = localtime_s(timer, buf);
+        if (0 == ret) {
+            (void)_sir_handleerr(ret);
+            return NULL;
+        }
+# endif
 
         return buf;
-#else /* !__HAVE_STDC_SECURE_OR_EXT1___ */
+#else /* !__HAVE_STDC_SECURE_OR_EXT1__ */
 # if !defined(__WIN__) || defined(__EMBARCADEROC__)
         struct tm* ret = localtime_r(timer, buf);
-# else /* __WIN__ */
+# else
         struct tm* ret = localtime(timer);
 # endif
         if (!ret)

--- a/src/sirinternal.c
+++ b/src/sirinternal.c
@@ -118,7 +118,9 @@ bool _sir_init(sirinit* si) {
 
     _SIR_LOCK_SECTION(sirconfig, _cfg, SIRMI_CONFIG, false);
 
+#if !defined(__WIN__)
     tzset();
+#endif
 
 #if defined(__HAVE_ATOMIC_H__)
     atomic_store(&_sir_magic, _SIR_MAGIC);

--- a/src/sirinternal.c
+++ b/src/sirinternal.c
@@ -118,6 +118,8 @@ bool _sir_init(sirinit* si) {
 
     _SIR_LOCK_SECTION(sirconfig, _cfg, SIRMI_CONFIG, false);
 
+    tzset();
+
 #if defined(__HAVE_ATOMIC_H__)
     atomic_store(&_sir_magic, _SIR_MAGIC);
 #else


### PR DESCRIPTION
* Use `localtime_r` for improved performance