### PR TITLE
Use system strlcat & strlcpy on Linux/glibc >= 2.38 and Haiku

### DIFF
--- a/include/sir/platform.h
+++ b/include/sir/platform.h
@@ -163,7 +163,21 @@ int pthread_getname_np(pthread_t thread, char* buffer, size_t length);
 #    if !defined(_GNU_SOURCE)
 #     define _GNU_SOURCE 1
 #    endif
-#    if defined(__GLIBC__) && __GLIBC_MINOR__ >= 12
+#    if defined(__has_include)
+#     if __has_include(<features.h>)
+#      include <features.h>
+#     endif
+#    endif
+#    if defined(__GLIBC__)
+#     if defined(GLIBC_VERSION)
+#      undef GLIBC_VERSION
+#     endif
+#     define GLIBC_VERSION (((0 + __GLIBC__) * 10000) + ((0 + __GLIBC_MINOR__) * 100))
+#    endif
+#    if !defined(GLIBC_VERSION)
+#     define GLIBC_VERSION 0
+#    endif
+#    if defined(__GLIBC__) && GLIBC_VERSION >= 21200
 #     define USE_PTHREAD_GETNAME_NP
 #    endif
 #   endif
@@ -235,7 +249,8 @@ _set_thread_local_invalid_parameter_handler(
 #  endif
 # endif
 
-# if !defined(__MACOS__) && !defined(__BSD__) && !defined(__SOLARIS__)
+# if !defined(__MACOS__) && !defined(__BSD__) && !defined(__SOLARIS__) && \
+     !(defined(__GLIBC__) && GLIBC_VERSION >= 23800)
 #  define SIR_IMPL_STRLCPY 1
 #  define SIR_IMPL_STRLCAT 1
 # endif

--- a/include/sir/platform.h
+++ b/include/sir/platform.h
@@ -250,7 +250,7 @@ _set_thread_local_invalid_parameter_handler(
 # endif
 
 # if !defined(__MACOS__) && !defined(__BSD__) && !defined(__SOLARIS__) && \
-     !(defined(__GLIBC__) && GLIBC_VERSION >= 23800)
+     !defined(__HAIKU__) && !(defined(__GLIBC__) && GLIBC_VERSION >= 23800)
 #  define SIR_IMPL_STRLCPY 1
 #  define SIR_IMPL_STRLCAT 1
 # endif

--- a/include/sir/platform.h
+++ b/include/sir/platform.h
@@ -28,9 +28,7 @@
 
 # if defined(_MSC_VER) && !defined(__clang__)
 #  include <stddef.h>
-#  if defined(_USE_ATTRIBUTES_FOR_SAL)
-#   undef _USE_ATTRIBUTES_FOR_SAL
-#  endif
+#  undef _USE_ATTRIBUTES_FOR_SAL
 #  define _USE_ATTRIBUTES_FOR_SAL 1
 #  include <sal.h>
 #  define PRINTF_FORMAT _Printf_format_string_
@@ -100,13 +98,9 @@
 #    undef __HAVE_ATOMIC_H__
 #   endif
 #  endif
-#  if defined(__STDC_WANT_LIB_EXT1__)
-#   undef __STDC_WANT_LIB_EXT1__
-#  endif
+#  undef __STDC_WANT_LIB_EXT1__
 #  define __STDC_WANT_LIB_EXT1__ 1
-#  if defined(__STDC_WANT_LIB_EXT2__)
-#   undef __STDC_WANT_LIB_EXT2__
-#  endif
+#  undef __STDC_WANT_LIB_EXT2__
 #  define __STDC_WANT_LIB_EXT2__ 1
 #  if defined(__APPLE__) && defined(__MACH__)
 #   define __MACOS__
@@ -169,9 +163,7 @@ int pthread_getname_np(pthread_t thread, char* buffer, size_t length);
 #     endif
 #    endif
 #    if defined(__GLIBC__)
-#     if defined(GLIBC_VERSION)
-#      undef GLIBC_VERSION
-#     endif
+#     undef GLIBC_VERSION
 #     define GLIBC_VERSION (((0 + __GLIBC__) * 10000) + ((0 + __GLIBC_MINOR__) * 100))
 #    endif
 #    if !defined(GLIBC_VERSION)

--- a/src/sirerrors.c
+++ b/src/sirerrors.c
@@ -36,10 +36,8 @@
 #if defined(__MACOS__) || defined(__BSD__) || \
     (defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200112L && !defined(_GNU_SOURCE)))
 # define __HAVE_XSI_STRERROR_R__
-# if defined(__GLIBC__)
-#  if (__GLIBC__ >= 2 && __GLIBC_MINOR__ < 13)
-#   define __HAVE_XSI_STRERROR_R_ERRNO__
-#  endif
+# if defined(__GLIBC__) && GLIBC_VERSION < 21300
+#  define __HAVE_XSI_STRERROR_R_ERRNO__
 # endif
 #elif defined(_GNU_SOURCE) && defined(__GLIBC__)
 # define __HAVE_GNU_STRERROR_R__

--- a/src/sirinternal.c
+++ b/src/sirinternal.c
@@ -1167,7 +1167,7 @@ pid_t _sir_gettid(void) {
 #elif defined(__HAIKU__)
     tid = get_pthread_thread_id(pthread_self());
 #elif defined(__linux__) || defined(__serenity__)
-# if (defined(__GLIBC__) && (__GLIBC__ >= 2 && __GLIBC_MINOR__ >= 30)) || \
+# if (defined(__GLIBC__) && GLIBC_VERSION >= 23000) || \
      defined(__serenity__)
     tid = gettid();
 # else
@@ -1184,7 +1184,7 @@ pid_t _sir_gettid(void) {
 bool _sir_getthreadname(char name[SIR_MAXPID]) {
 #if defined(__MACOS__) || \
    (defined(__BSD__) && defined(__FreeBSD_PTHREAD_NP_12_2__)) || \
-   (defined(__GLIBC__) && __GLIBC_MINOR__ >= 12 && defined(_GNU_SOURCE)) || \
+   (defined(__GLIBC__) && GLIBC_VERSION >= 21200 && defined(_GNU_SOURCE)) || \
     defined(USE_PTHREAD_GETNAME_NP)
     int ret = pthread_getname_np(pthread_self(), name, SIR_MAXPID);
     if (0 != ret)


### PR DESCRIPTION
* Use system `strlcat` and `strlcpy` on Linux/glibc >= 2.38
* Use system `strlcat` and `strlcpy` on Haiku
* Improve glibc version checking macros