### PR TITLE
Fix SIR_OS_LOG_ENABLED

### DIFF
--- a/include/sir/platform.h
+++ b/include/sir/platform.h
@@ -296,7 +296,8 @@ _set_thread_local_invalid_parameter_handler(
 # include <time.h>
 
 # if !defined(SIR_NO_SYSTEM_LOGGERS)
-#  if defined(__MACOS__) && !defined(__GNUC__)
+#  if defined(__MACOS__) && ((defined(__clang__) || defined(__clang_version__)) && \
+      defined(__clang_major__) && defined(__clang_minor__) && defined(__clang_patchlevel__))
 #   define SIR_OS_LOG_ENABLED
 #  else
 #   undef SIR_OS_LOG_ENABLED

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -2387,7 +2387,7 @@ void os_log_parent_activity(void* ctx) {
     float rock_count = 0.0f;
     os_activity_apply_f(child, (void*)&rock_count, os_log_child_activity);
     sir_info("astronauts safely back on board. official count: ~%.02f moon rocks",
-        rock_count);
+        (double)rock_count);
 }
 
 void os_log_child_activity(void* ctx) {
@@ -2398,7 +2398,7 @@ void os_log_child_activity(void* ctx) {
     }
 
     float* rock_count = (float*)ctx;
-    *rock_count = 1e12;
+    *rock_count = 1e12f;
     sir_info("all sectors counted; heading back to the lunar lander");
 }
 #endif


### PR DESCRIPTION
- Detection was broken at the preprocessor level. Fixed it so that if the target system is macOS and the compiler is Clang, define.
- Fixed two implicit conversion warnings that we didn't catch because this preprocessor macro was never enabled.