### PR TITLE
Don't use variable name 'n' in macro

### DIFF
--- a/include/sir/helpers.h
+++ b/include/sir/helpers.h
@@ -340,8 +340,8 @@ uint32_t FNV32_1a(const uint8_t* data, size_t len) {
  */
 # define _sir_snprintf_trunc(dst, size, ...) \
     do { \
-      volatile size_t n = size; \
-      (void)snprintf(dst, n, __VA_ARGS__); \
+      volatile size_t _n = size; \
+      (void)snprintf(dst, _n, __VA_ARGS__); \
     } while (false)
 
 /**


### PR DESCRIPTION
I always write `n` in my for-loops. cppcheck caught this one.