### PR TITLE
don't fstat log files on every write, only every n

### DIFF
--- a/include/sir/config.h
+++ b/include/sir/config.h
@@ -341,6 +341,12 @@
  */
 # define SIR_THRD_CHK_INTERVAL 333.0
 
+/**
+ * The number of writes to a file to let occur before checking its current size to
+ * determine if it needs to be rolled.
+ */
+# define SIR_FILE_CHK_SIZE_WRITES 10
+
 # if defined(SIR_OS_LOG_ENABLED)
 /**
  * The special format specifier to send to os_log. By default, the log will only

--- a/include/sir/types.h
+++ b/include/sir/types.h
@@ -291,6 +291,7 @@ typedef struct {
     sir_options opts;
     FILE* f;
     sirfileid id;
+    int writes_since_size_chk;
 } sirfile;
 
 /** Log file cache. */

--- a/src/sirfilecache.c
+++ b/src/sirfilecache.c
@@ -127,25 +127,29 @@ bool _sirfile_write(sirfile* sf, const char* output) {
     if (!_sirfile_validate(sf) || !_sir_validstr(output))
         return false;
 
-    if (_sirfile_needsroll(sf)) {
-        bool rolled   = false;
-        char* newpath = NULL;
+    if (sf->writes_since_size_chk++ > SIR_FILE_CHK_SIZE_WRITES) {
+        sf->writes_since_size_chk = 0;
 
-        _sir_selflog("file (path: '%s', id: %"PRIx32") reached ~%d bytes in size;"
-                     " rolling...", sf->path, sf->id, SIR_FROLLSIZE);
+        if (_sirfile_needsroll(sf)) {
+            bool rolled   = false;
+            char* newpath = NULL;
 
-        _sir_fflush(sf->f);
+            _sir_selflog("file (path: '%s', id: %"PRIx32") reached ~%d bytes in size;"
+                         " rolling...", sf->path, sf->id, SIR_FROLLSIZE);
 
-        if (_sirfile_roll(sf, &newpath)) {
-            char header[SIR_MAXFHEADER] = {0};
-            (void)snprintf(header, SIR_MAXFHEADER, SIR_FHROLLED, newpath);
-            rolled = _sirfile_writeheader(sf, header);
+            _sir_fflush(sf->f);
+
+            if (_sirfile_roll(sf, &newpath)) {
+                char header[SIR_MAXFHEADER] = {0};
+                (void)snprintf(header, SIR_MAXFHEADER, SIR_FHROLLED, newpath);
+                rolled = _sirfile_writeheader(sf, header);
+            }
+
+            _sir_safefree(&newpath);
+            if (!rolled) /* write anyway; don't want to lose data. */
+                _sir_selflog("error: failed to roll file (path: '%s', id: %" PRIx32")!",
+                    sf->path, sf->id);
         }
-
-        _sir_safefree(&newpath);
-        if (!rolled) /* write anyway; don't want to lose data. */
-            _sir_selflog("error: failed to roll file (path: '%s', id: %" PRIx32")!",
-                sf->path, sf->id);
     }
 
     size_t writeLen = strnlen(output, SIR_MAXOUTPUT);


### PR DESCRIPTION
Should improve write perf since fstat() is such a heavy call. There's no need to check it on every write, since relative to the roll size, one write is barely a dent.