### PR TITLE
Require AVX tag on NVIDIA CI job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -272,6 +272,7 @@ Linux/x86_64 (NVIDIA HPC C/C++):
   tags:
     - Docker-x64
     - Linux
+    - AVX
   image:
     name: registry.gitlab.com/libsir/libsir/nvhpc:latest
   script:


### PR DESCRIPTION
* Require AVX tag on NVIDIA CI job