### PR TITLE
Some minor fixes for ucLibc-ng toolchains

### DIFF
--- a/src/sirinternal.c
+++ b/src/sirinternal.c
@@ -1149,6 +1149,7 @@ pid_t _sir_gettid(void) {
 bool _sir_getthreadname(char name[SIR_MAXPID]) {
     _sir_resetstr(name);
 #if defined(__MACOS__) || (defined(__BSD__) && defined(__FreeBSD_PTHREAD_NP_12_2__)) || \
+    (defined(__linux__) && defined(__UCLIBC__) && defined(_GNU_SOURCE)) || \
     (defined(__GLIBC__) && GLIBC_VERSION >= 21200 && defined(_GNU_SOURCE)) || \
     (defined(__ANDROID__) &&  __ANDROID_API__ >= 26) || defined(SIR_PTHREAD_GETNAME_NP) || \
     defined(__serenity__) || (defined(__linux__) && !defined(__GLIBC__) && \
@@ -1208,6 +1209,7 @@ bool _sir_setthreadname(const char* name) {
     int ret = pthread_setname_np(pthread_self(), "%s", name);
     return (0 != ret) ? _sir_handleerr(ret) : true;
 #elif (defined(__BSD__) && defined(__FreeBSD_PTHREAD_NP_12_2__)) || \
+      (defined(__linux__) && defined(__UCLIBC__) && defined(_GNU_SOURCE)) || \
       (defined(__GLIBC__) && GLIBC_VERSION >= 21200 && defined(_GNU_SOURCE)) || \
        defined(__QNXNTO__) || defined(__SOLARIS__) || defined(SIR_PTHREAD_GETNAME_NP) || \
        defined(__ANDROID__) && !defined(__OpenBSD__) || defined(__serenity__) || \

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -2362,8 +2362,7 @@ bool filter_error(bool pass, uint16_t err) {
 uint32_t getrand(uint32_t upper_bound) {
 #if !defined(__WIN__) || defined(__EMBARCADEROC__)
 # if defined(__MACOS__) || defined(__BSD__) || defined(__serenity__) || \
-     defined(__SOLARIS__) || defined(__ANDROID__) || \
-     (defined(__linux__) && defined(__UCLIBC__)) || defined(__CYGWIN__) || \
+     defined(__SOLARIS__) || defined(__ANDROID__) || defined(__CYGWIN__) || \
      (defined(__linux__) && defined(__GLIBC__) && GLIBC_VERSION >= 23600)
     if (upper_bound < 2U)
         upper_bound = 2U;


### PR DESCRIPTION
* Fix `_sir_getthreadname` and `_sir_setthreadname`
* Don't use `arc4random_uniform`