### PR TITLE
macroize _sir_valid* functions in order to capture source info

### DIFF
--- a/include/sir/helpers.h
+++ b/include/sir/helpers.h
@@ -93,10 +93,11 @@
 
 /* Validates a pointer and optionally fails if it's invalid. */
 static inline
-bool __sir_validptr(const void* restrict p, bool fail) {
+bool __sir_validptr(const void* restrict p, bool fail, const char* func,
+    const char* file, uint32_t line) {
     bool valid = NULL != p;
     if (fail && !valid) {
-        (void)_sir_seterror(_SIR_E_NULLPTR);
+        (void)__sir_seterror(_SIR_E_NULLPTR, func, file, line);
         SIR_ASSERT(!valid && fail);
     }
     return valid;
@@ -104,26 +105,31 @@ bool __sir_validptr(const void* restrict p, bool fail) {
 
 /** Validates a pointer-to-pointer and optionally fails if it's invalid. */
 static inline
-bool __sir_validptrptr(const void* restrict* pp, bool fail) {
+bool __sir_validptrptr(const void* restrict* pp, bool fail, const char* func,
+    const char* file, uint32_t line) {
     bool valid = NULL != pp;
     if (fail && !valid) {
-        (void)_sir_seterror(_SIR_E_NULLPTR);
+        (void)__sir_seterror(_SIR_E_NULLPTR, func, file, line);
         SIR_ASSERT(!valid && fail);
     }
     return valid;
 }
 
 /** Validates a pointer but ignores whether it's invalid. */
-# define _sir_validptrnofail(p) __sir_validptr(p, false)
+# define _sir_validptrnofail(p) \
+    __sir_validptr(p, false, __func__, __file__, __LINE__)
 
 /** Validates a pointer and fails if it's invalid. */
-# define _sir_validptr(p) __sir_validptr((const void* restrict)p, true)
+# define _sir_validptr(p) \
+    __sir_validptr((const void* restrict)p, true, __func__, __file__, __LINE__)
 
 /** Validates a pointer-to-function and fails if it's invalid. */
-# define _sir_validfnptr(fnp) __sir_validptrptr((const void* restrict*)&fnp, true)
+# define _sir_validfnptr(fnp) \
+    __sir_validptrptr((const void* restrict*)&fnp, true, __func__, __file__, __LINE__)
 
 /** Validates a pointer-to-pointer and fails if it's invalid. */
-# define _sir_validptrptr(pp) __sir_validptrptr((const void* restrict*)pp, true)
+# define _sir_validptrptr(pp) \
+    __sir_validptrptr((const void* restrict*)pp, true, __func__, __file__, __LINE__)
 
 /** Checks a bitmask for a specific set of bits. */
 static inline
@@ -188,13 +194,28 @@ bool _sir_validpluginid(sirpluginid id) {
 }
 
 /** Validates a sir_update_config_data structure. */
-bool _sir_validupdatedata(const sir_update_config_data* data);
+bool __sir_validupdatedata(const sir_update_config_data* data, const char* func,
+    const char* file, uint32_t line);
+
+/** Validates a sir_update_config_data structure. */
+# define _sir_validupdatedata(data) \
+    __sir_validupdatedata(data, __func__, __file__, __LINE__)
 
 /** Validates a set of ::sir_level flags. */
-bool _sir_validlevels(sir_levels levels);
+bool __sir_validlevels(sir_levels levels, const char* func, const char* file,
+    uint32_t line);
+
+/** Validates a set of ::sir_level flags. */
+# define _sir_validlevels(levels) \
+    __sir_validlevels(levels, __func__, __file__, __LINE__)
 
 /** Validates a single ::sir_level. */
-bool _sir_validlevel(sir_level level);
+bool __sir_validlevel(sir_level level, const char* func, const char* file,
+    uint32_t line);
+
+/** Validates a single ::sir_level. */
+# define _sir_validlevel(level) \
+    __sir_validlevel(level, __func__, __file__, __LINE__)
 
 /** Applies default ::sir_level flags if applicable. */
 static inline
@@ -211,16 +232,36 @@ void _sir_defaultopts(sir_options* opts, sir_options def) {
 }
 
 /** Validates a set of ::sir_option flags. */
-bool _sir_validopts(sir_options opts);
+bool __sir_validopts(sir_options opts, const char* func, const char* file,
+    uint32_t line);
+
+/** Validates a set of ::sir_option flags. */
+# define _sir_validopts(opts) \
+    __sir_validopts(opts, __func__, __file__, __LINE__)
 
 /** Validates a ::sir_textattr. */
-bool _sir_validtextattr(sir_textattr attr);
+bool __sir_validtextattr(sir_textattr attr, const char* func, const char* file,
+    uint32_t line);
+
+/** Validates a ::sir_textattr. */
+# define _sir_validtextattr(attr) \
+    __sir_validtextattr(attr, __func__, __file__, __LINE__)
 
 /** Validates a ::sir_textcolor based on color mode. */
-bool _sir_validtextcolor(sir_colormode mode, sir_textcolor color);
+bool __sir_validtextcolor(sir_colormode mode, sir_textcolor color, const char* func,
+    const char* file, uint32_t line);
+
+/** Validates a ::sir_textcolor based on color mode. */
+# define _sir_validtextcolor(mode, color) \
+    __sir_validtextcolor(mode, color, __func__, __file__, __LINE__)
 
 /** Validates a ::sir_colormode. */
-bool _sir_validcolormode(sir_colormode mode);
+bool __sir_validcolormode(sir_colormode mode, const char* func, const char* file,
+    uint32_t line);
+
+/** Validates a ::sir_colormode. */
+# define _sir_validcolormode(mode) \
+    __sir_validcolormode(mode, __func__, __file__, __LINE__)
 
 /** Converts a SIRTC_* value to a 16-color mode ANSI foreground color. */
 static inline
@@ -276,20 +317,23 @@ sir_textcolor _sir_makergb(sir_textcolor r, sir_textcolor g, sir_textcolor b) {
 
 /** Validates a string pointer and optionally fails if it's invalid. */
 static inline
-bool __sir_validstr(const char* restrict str, bool fail) {
+bool __sir_validstr(const char* restrict str, bool fail, const char* func,
+    const char* file, uint32_t line) {
     bool valid = str && *str != '\0';
     if (fail && !valid) {
-        (void)_sir_seterror(_SIR_E_STRING);
         SIR_ASSERT(!valid && fail);
+        (void)__sir_seterror(_SIR_E_STRING, func, file, line);
     }
     return valid;
 }
 
 /** Validates a string pointer and fails if it's invalid. */
-# define _sir_validstr(str) __sir_validstr(str, true)
+# define _sir_validstr(str) \
+    __sir_validstr(str, true, __func__, __file__, __LINE__)
 
 /** Validates a string pointer but ignores whether it's invalid. */
-# define _sir_validstrnofail(str) __sir_validstr(str, false)
+# define _sir_validstrnofail(str) \
+    __sir_validstr(str, false, __func__, __file__, __LINE__)
 
 /** Places a null terminator at the first index in a string buffer. */
 static inline

--- a/src/sirhelpers.c
+++ b/src/sirhelpers.c
@@ -87,7 +87,8 @@ bool _sir_validfd(int fd) {
 }
 
 /** Validates a sir_update_config_data structure. */
-bool _sir_validupdatedata(const sir_update_config_data* data) {
+bool __sir_validupdatedata(const sir_update_config_data* data, const char* func,
+    const char* file, uint32_t line) {
     if (!_sir_validptr(data))
         return false;
 
@@ -110,14 +111,15 @@ bool _sir_validupdatedata(const sir_update_config_data* data) {
         valid = _sir_validstrnofail(data->sl_category);
 
     if (!valid) {
-        (void)_sir_seterror(_SIR_E_INVALID);
+        (void)__sir_seterror(_SIR_E_INVALID, func, file, line);
         SIR_ASSERT(!valid);
     }
 
     return valid;
 }
 
-bool _sir_validlevels(sir_levels levels) {
+bool __sir_validlevels(sir_levels levels, const char* func,
+    const char* file, uint32_t line) {
     if ((SIRL_ALL == levels || SIRL_NONE == levels) ||
         ((_sir_bittest(levels, SIRL_INFO)           ||
          _sir_bittest(levels, SIRL_DEBUG)           ||
@@ -131,10 +133,11 @@ bool _sir_validlevels(sir_levels levels) {
          return true;
 
     _sir_selflog("invalid levels: %04"PRIx16, levels);
-    return _sir_seterror(_SIR_E_LEVELS);
+    return __sir_seterror(_SIR_E_LEVELS, func, file, line);
 }
 
-bool _sir_validlevel(sir_level level) {
+bool __sir_validlevel(sir_level level, const char* func, const char* file,
+    uint32_t line) {
     if (SIRL_INFO   == level || SIRL_DEBUG == level ||
         SIRL_NOTICE == level || SIRL_WARN  == level ||
         SIRL_ERROR  == level || SIRL_CRIT  == level ||
@@ -142,10 +145,11 @@ bool _sir_validlevel(sir_level level) {
         return true;
 
     _sir_selflog("invalid level: %04"PRIx16, level);
-    return _sir_seterror(_SIR_E_LEVELS);
+    return __sir_seterror(_SIR_E_LEVELS, func, file, line);
 }
 
-bool _sir_validopts(sir_options opts) {
+bool __sir_validopts(sir_options opts, const char* func, const char* file,
+    uint32_t line) {
     if ((SIRO_ALL == opts || SIRO_MSGONLY == opts) ||
         ((_sir_bittest(opts, SIRO_NOTIME)          ||
          _sir_bittest(opts, SIRO_NOHOST)           ||
@@ -159,10 +163,11 @@ bool _sir_validopts(sir_options opts) {
          return true;
 
     _sir_selflog("invalid options: %08"PRIx32, opts);
-    return _sir_seterror(_SIR_E_OPTIONS);
+    return __sir_seterror(_SIR_E_OPTIONS, func, file, line);
 }
 
-bool _sir_validtextattr(sir_textattr attr) {
+bool __sir_validtextattr(sir_textattr attr, const char* func, const char* file,
+    uint32_t line) {
     switch(attr) {
         case SIRTA_NORMAL:
         case SIRTA_BOLD:
@@ -172,12 +177,13 @@ bool _sir_validtextattr(sir_textattr attr) {
             return true;
         default: {
             _sir_selflog("invalid text attr: %d", attr);
-            return _sir_seterror(_SIR_E_TEXTATTR);
+            return __sir_seterror(_SIR_E_TEXTATTR, func, file, line);
         }
     }
 }
 
-bool _sir_validtextcolor(sir_colormode mode, sir_textcolor color) {
+bool __sir_validtextcolor(sir_colormode mode, sir_textcolor color, const char* func,
+    const char* file, uint32_t line) {
     bool valid = false;
     switch (mode) {
         case SIRCM_16:
@@ -207,13 +213,14 @@ bool _sir_validtextcolor(sir_colormode mode, sir_textcolor color) {
     if (!valid) {
         _sir_selflog("invalid text color for mode %d %08"PRIx32" (%"PRIu32")",
             mode, color, color);
-        (void)_sir_seterror(_SIR_E_TEXTCOLOR);
+        (void)__sir_seterror(_SIR_E_TEXTCOLOR, func, file, line);
     }
 
     return valid;
 }
 
-bool _sir_validcolormode(sir_colormode mode) {
+bool __sir_validcolormode(sir_colormode mode, const char* func, const char* file,
+    uint32_t line) {
     switch (mode) {
         case SIRCM_16:
         case SIRCM_256:
@@ -222,7 +229,7 @@ bool _sir_validcolormode(sir_colormode mode) {
         case SIRCM_INVALID:
         default: {
             _sir_selflog("invalid color mode: %d", mode);
-            return _sir_seterror(_SIR_E_COLORMODE);
+            return __sir_seterror(_SIR_E_COLORMODE, func, file, line);
         }
     }
 }

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -2051,13 +2051,13 @@ bool sirtest_pluginloader(void) {
     print_test_error(pass, pass);
 
     /* try to unload the plugin again. */
-    printf("\nunloading already unloaded plugin '%s'...\n", plugin1);
+    printf("\tunloading already unloaded plugin '%s'...\n", plugin1);
     _sir_eqland(pass, !sir_unloadplugin(id));
 
     print_test_error(pass, pass);
 
     /* test bad paths. */
-    printf("\ntrying to load plugin with NULL path...\n");
+    printf("\ttrying to load plugin with NULL path...\n");
     badid = sir_loadplugin(NULL);
     _sir_eqland(pass, 0 == badid);
 


### PR DESCRIPTION
* As-is, some errors will always appear to be originating from sirhelpers.c, which is not useful. Changing these to macros will allow us to capture __func__, __file__, __LINE__, and store that in the error information.
* Also fixed a minor bug in plugin loader test