### PR TITLE
_sir_validstrnofail does not need to call __sir_validstr

### DIFF
--- a/include/sir/helpers.h
+++ b/include/sir/helpers.h
@@ -317,11 +317,11 @@ sir_textcolor _sir_makergb(sir_textcolor r, sir_textcolor g, sir_textcolor b) {
 
 /** Validates a string pointer and optionally fails if it's invalid. */
 static inline
-bool __sir_validstr(const char* restrict str, bool fail, const char* func,
+bool __sir_validstr(const char* restrict str, const char* func,
     const char* file, uint32_t line) {
     bool valid = str && *str != '\0';
-    if (fail && !valid) {
-        SIR_ASSERT(!valid && fail);
+    if (!valid) {
+        SIR_ASSERT(valid);
         (void)__sir_seterror(_SIR_E_STRING, func, file, line);
     }
     return valid;
@@ -329,11 +329,10 @@ bool __sir_validstr(const char* restrict str, bool fail, const char* func,
 
 /** Validates a string pointer and fails if it's invalid. */
 # define _sir_validstr(str) \
-    __sir_validstr(str, true, __func__, __file__, __LINE__)
+    __sir_validstr(str, __func__, __file__, __LINE__)
 
 /** Validates a string pointer but ignores whether it's invalid. */
-# define _sir_validstrnofail(str) \
-    __sir_validstr(str, false, __func__, __file__, __LINE__)
+# define _sir_validstrnofail(str) (NULL != (str) && '\0' != *(str))
 
 /** Places a null terminator at the first index in a string buffer. */
 static inline


### PR DESCRIPTION
This should give us a tiny perf gain, and eliminates a useless code path.