### PR TITLE
add `sir_isinitialized` convenience function

### DIFF
--- a/include/sir.h
+++ b/include/sir.h
@@ -422,12 +422,12 @@ bool sir_remfile(sirfileid id);
  * @see ::sir_unloadplugin
  * @see ::plugins
  *
- * @param  path        The absolute or relative path of the plugin to be loaded
- *                     and registered.
- * @return sirpluginid If successful, a unique identifier that may later be used
- *                     to unload the plugin module. Upon failure, returns zero.
- *                     Use ::sir_geterror to obtain information about any error
- *                     that may have occurred.
+ * @param  path         The absolute or relative path of the plugin to be loaded
+ *                      and registered.
+ * @returns sirpluginid If successful, a unique identifier that may later be used
+ *                      to unload the plugin module. Upon failure, returns zero.
+ *                      Use ::sir_geterror to obtain information about any error
+ *                      that may have occurred.
  */
 sirpluginid sir_loadplugin(const char* path);
 

--- a/include/sir.h
+++ b/include/sir.h
@@ -55,7 +55,8 @@ extern "C" {
  * @brief Fills out a ::sirinit structure with default values.
  *
  * Creates an initialization configuration for libsir essentially using all of
- * the default values (i.e., levels, options, text styling).
+ * the default values (i.e., level registrations, formatting options, and text
+ * styling).
  *
  * @note Does not fill in string fields, such as ::sirinit.name.
  *
@@ -506,8 +507,7 @@ bool sir_settextstyle(sir_level level, sir_textattr attr, sir_textcolor fg,
  * @see ::default
  *
  * @returns bool `true` if successfully reset, `false` otherwise. Use
- *          ::sir_geterror to obtain information about any error that may have
- *          occurred.
+ * ::sir_geterror to obtain information about any error that may have occurred.
  */
 bool sir_resettextstyles(void);
 
@@ -726,8 +726,8 @@ bool sir_syslogid(const char* identity);
  *
  * Upon library initialization, the system logger category is resolved as follows:
  *
- * 1. If the @ref sir_syslog_dest.category "sirinit.d_syslog.category" string is set,
- *    it will be used.
+ * 1. If the @ref sir_syslog_dest.category "sirinit.d_syslog.category" string is
+ *    set, it will be used.
  * 2. The string ::SIR_FALLBACK_SYSLOG_CAT will be used.
  *
  * @remark If `SIR_NO_SYSTEM_LOGGERS` is defined when compiling libsir, this
@@ -754,7 +754,7 @@ bool sir_syslogcat(const char* category);
  * 2.2.4-dev
  * ~~~
  *
- * @return const char* The current libsir version string.
+ * @returns const char* The current libsir version string.
  */
 const char* sir_getversionstring(void);
 
@@ -763,7 +763,7 @@ const char* sir_getversionstring(void);
  *
  * @note Can be formatted as a hexadecimal number with %08x.
  *
- * @return uint32_t The current libsir version number.
+ * @returns uint32_t The current libsir version number.
  */
 uint32_t sir_getversionhex(void);
 

--- a/include/sir.h
+++ b/include/sir.h
@@ -104,6 +104,21 @@ bool sir_init(sirinit* si);
 bool sir_cleanup(void);
 
 /**
+ * @brief Determines whether or not libsir is in the initialized state.
+ *
+ * Provided as a convenience method to detect whether libsir requires initial-
+ * ization or cleanup at any given time.
+ *
+ * @remark Calling ::sir_init after libsir is initialized produces an error.
+ * Similarly, ::sir_cleanup behaves the same way if libsir is not initialized.
+ *
+ * @returns bool `true` if ::sir_init has been called and libsir is initialized;
+ * `false` if ::sir_init has not yet been called, or a corresponding call to
+ * ::sir_cleanup has already been made.
+ */
+bool sir_isinitialized(void);
+
+/**
  * @brief Retrieves information about the last error that occurred.
  *
  * libsir maintains errors on a per-thread basis, so it's important that the

--- a/include/sir/internal.h
+++ b/include/sir/internal.h
@@ -43,6 +43,12 @@ bool _sir_init(sirinit* si);
 bool _sir_cleanup(void);
 
 /** Evaluates whether or not libsir has been initialized. */
+bool _sir_isinitialized(void);
+
+/**
+ * Evaluates whether or not libsir has been initialized, and sets the last
+ * error to SIR_E_NOTREADY if not initialized.
+ */
 bool _sir_sanity(void);
 
 /** Validates the configuration passed to ::sir_init. */

--- a/src/sir.c
+++ b/src/sir.c
@@ -46,6 +46,10 @@ bool sir_cleanup(void) {
     return _sir_cleanup();
 }
 
+bool sir_isinitialized(void) {
+    return _sir_isinitialized();
+}
+
 uint16_t sir_geterror(char message[SIR_MAXERROR]) {
     return _sir_geterrcode(_sir_geterror(message));
 }

--- a/src/sirinternal.c
+++ b/src/sirinternal.c
@@ -229,7 +229,7 @@ bool _sir_cleanup(void) {
     return cleanup;
 }
 
-bool _sir_sanity(void) {
+bool _sir_isinitialized(void) {
 #if defined(__HAVE_ATOMIC_H__)
     if (_SIR_MAGIC == atomic_load(&_sir_magic))
         return true;
@@ -237,6 +237,12 @@ bool _sir_sanity(void) {
     if (_SIR_MAGIC == _sir_magic)
         return true;
 #endif
+    return false;
+}
+
+bool _sir_sanity(void) {
+    if (_sir_isinitialized())
+        return true;
     return _sir_seterror(_SIR_E_NOTREADY);
 }
 

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -41,6 +41,7 @@ static sir_test sir_tests[] = {
     {"file-remove-nonexistent", sirtest_failremovebadfile, false, true},
     {"file-archive-large",      sirtest_rollandarchivefile, false, true},
     {"init-output-before",      sirtest_failwithoutinit, false, true},
+    {"init-check-state",        sirtest_isinitialized, false, true},
     {"init-superfluous",        sirtest_failinittwice, false, true},
     {"init-bad-data",           sirtest_failinvalidinitdata, false, true},
     {"init-cleanup-init",       sirtest_initcleanupinit, false, true},
@@ -725,6 +726,27 @@ bool sirtest_failwithoutinit(void) {
 
     if (pass)
         print_expected_error();
+
+    return print_result_and_return(pass);
+}
+
+bool sirtest_isinitialized(void) {
+    // TODO: replace printfs with TEST_MSG_0 after python branch is merged in.
+    bool pass = true;
+
+    (void)printf("\tchecking sir_isinitialized before initialization...");
+    _sir_eqland(pass, !sir_isinitialized());
+
+    INIT(si, SIRL_ALL, 0, 0, 0);
+    _sir_eqland(pass, si_init);
+
+    (void)printf("\tchecking sir_isinitialized after initialization...");
+    _sir_eqland(pass, sir_isinitialized());
+
+    _sir_eqland(pass, sir_cleanup());
+
+    (void)printf("\tchecking sir_isinitialized after cleanup...");
+    _sir_eqland(pass, !sir_isinitialized());
 
     return print_result_and_return(pass);
 }

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -170,6 +170,12 @@ bool sirtest_rollandarchivefile(void);
 bool sirtest_failwithoutinit(void);
 
 /**
+ * @test Correctly determines the initialized state.
+ * @returns bool `true` if the test passed, `false` otherwise.
+ */
+bool sirtest_isinitialized(void);
+
+/**
  * @test Properly handle two initialization calls without corresponding cleanup.
  * @returns bool `true` if the test passed, `false` otherwise.
  */


### PR DESCRIPTION
* Determines whether or not libsir is in the initialized state without setting an error if it is not.