### PR TITLE
Add sir_geterrorinfo to obtain extended information about an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The Makefiles are compatible with **GNU Make** version **3.81** and later (**4.4
 | Test suite (C++) |  `make tests++`  | <ul><li>*build/bin/sirtests++[.exe]*</li></ul> |
 | Example app      |  `make example`  | <ul><li>*build/bin/sirexample[.exe]*</li></ul> |
 | Static library   |  `make static`   | <ul><li>*build/lib/libsir_s.a*</li></ul>       |
-| Shared library   |  `make shared`   | <ul><li>*build/lib/libsir.so*</il></ul>        |
+| Shared library   |  `make shared`   | <ul><li>*build/lib/libsir.so*</li></ul>        |
 | Installation     |  `make install`  | <ul><li>*$PREFIX/lib/libsir_s.a*</li><li>*$PREFIX/lib/libsir.so*</li><li>*$PREFIX/include/sir.h*</li><li>*$PREFIX/include/sir/\*.h*</li></ul> |
 
 ## <a id="dig-in" /> Dig in

--- a/bindings/python/sir.i
+++ b/bindings/python/sir.i
@@ -54,7 +54,7 @@
 %rename(TextColor) sir_textcolor;
 %ignore sir_colormode;
 %rename(ColorMode) sir_colormode;
-%ignore sir_errinfo
+%ignore sir_errinfo;
 %rename(ErrorInfo) sir_errinfo;
 
 /* constants/enums. */

--- a/bindings/python/sir.i
+++ b/bindings/python/sir.i
@@ -211,7 +211,7 @@
 %rename(cleanup) sir_cleanup;
 %ignore sir_geterror;
 %rename(geterror) sir_geterror;
-%ignore sir_geterrorinfo
+%ignore sir_geterrorinfo;
 %rename (geterrorinfo) sir_geterrorinfo;
 %ignore sir_debug;
 %rename(debug) sir_debug;

--- a/bindings/python/sir.i
+++ b/bindings/python/sir.i
@@ -54,6 +54,8 @@
 %rename(TextColor) sir_textcolor;
 %ignore sir_colormode;
 %rename(ColorMode) sir_colormode;
+%ignore sir_errinfo
+%rename(ErrorInfo) sir_errinfo;
 
 /* constants/enums. */
 %ignore SIRL_NONE;
@@ -209,6 +211,8 @@
 %rename(cleanup) sir_cleanup;
 %ignore sir_geterror;
 %rename(geterror) sir_geterror;
+%ignore sir_geterrorinfo
+%rename (geterrorinfo) sir_geterrorinfo;
 %ignore sir_debug;
 %rename(debug) sir_debug;
 %ignore sir_info;

--- a/bindings/python/sir.i
+++ b/bindings/python/sir.i
@@ -54,8 +54,8 @@
 %rename(TextColor) sir_textcolor;
 %ignore sir_colormode;
 %rename(ColorMode) sir_colormode;
-%ignore sir_errinfo;
-%rename(ErrorInfo) sir_errinfo;
+%ignore sir_errorinfo;
+%rename(ErrorInfo) sir_errorinfo;
 
 /* constants/enums. */
 %ignore SIRL_NONE;

--- a/include/sir.h
+++ b/include/sir.h
@@ -150,8 +150,8 @@ uint16_t sir_geterror(char message[SIR_MAXERROR]);
  * the same thread that encountered a failed library call be the one to retrieve
  * the error message.
  *
- * @param   err  Pointer to a ::sir_errinfo structure into which the error infor-
- *               mation is placed.
+ * @param err Pointer to a ::sir_errinfo structure into which the error infor-
+ *            mation is placed.
  */
 void sir_geterrorinfo(sir_errinfo* err);
 

--- a/include/sir.h
+++ b/include/sir.h
@@ -96,8 +96,8 @@ bool sir_init(sirinit* si);
  *
  * Deallocates resources such as memory buffers, file descriptors, etc. and
  * resets the internal state. No calls into libsir will succeed after calling
- * ::sir_cleanup (with the exception of ::sir_makeinit, ::sir_init, and
- * ::sir_geterror).
+ * ::sir_cleanup (with the exception of ::sir_makeinit, ::sir_init,
+ * ::sir_isinitialized,::sir_geterror, and ::sir_geterrorinfo).
  *
  * May be called from any thread. If you wish to utilize libsir again during the
  * same process' lifetime, simply call ::sir_init again.
@@ -123,17 +123,38 @@ bool sir_cleanup(void);
 bool sir_isinitialized(void);
 
 /**
- * @brief Retrieves information about the last error that occurred.
+ * @brief Retrieves a formatted message for the last error that occurred on the
+ * calling thread and returns the associated error code.
  *
- * libsir maintains errors on a per-thread basis, so it's important that the
- * same thread that encountered a failed library call be the one to get the
- * error information.
+ * To retrieve more granular information about an error, or to customize the
+ * error message format, use ::sir_geterrorinfo.
  *
- * @param   message  A buffer of ::SIR_MAXERROR chars to receive an error message.
- * @returns uint16_t The error code. Possible error codes are listed in
- *                   ::sir_errorcode.
+ * @remark libsir maintains errors on a per-thread basis, so it's important that
+ * the same thread that encountered a failed library call be the one to retrieve
+ * the error message.
+ *
+ * @param   message  A buffer of ::SIR_MAXERROR chars into which the error message
+ *                   is placed.
+ * @returns uint16_t An error code. Codes are listed in ::sir_errorcode. If no
+ *                   error has occurred, returns ::SIR_E_NOERROR.
  */
 uint16_t sir_geterror(char message[SIR_MAXERROR]);
+
+/**
+ * @brief Retrieves granular information about the last error that occurred on
+ * the calling thread.
+ *
+ * To retrieve just an error code and a formatted message, use ::sir_geterror.
+ *
+ * @remark libsir maintains errors on a per-thread basis, so it's important that
+ * the same thread that encountered a failed library call be the one to retrieve
+ * the error message.
+ *
+ * @param   err  Pointer to a ::sir_errinfo structure into which the error infor-
+ *               mation is placed.
+ * @returns void
+ */
+void sir_geterrorinfo(sir_errinfo* err);
 
 /**
  * @brief Dispatches a ::SIRL_DEBUG level message.

--- a/include/sir.h
+++ b/include/sir.h
@@ -152,7 +152,6 @@ uint16_t sir_geterror(char message[SIR_MAXERROR]);
  *
  * @param   err  Pointer to a ::sir_errinfo structure into which the error infor-
  *               mation is placed.
- * @returns void
  */
 void sir_geterrorinfo(sir_errinfo* err);
 

--- a/include/sir.h
+++ b/include/sir.h
@@ -135,8 +135,8 @@ bool sir_isinitialized(void);
  *
  * @param   message  A buffer of ::SIR_MAXERROR chars into which the error message
  *                   is placed.
- * @returns uint16_t An error code. Codes are listed in ::sir_errorcode. If no
- *                   error has occurred, returns ::SIR_E_NOERROR.
+ * @returns uint16_t An error code (see ::sir_errorcode). Returns ::SIR_E_NOERROR
+ *                   if no error has occurred.
  */
 uint16_t sir_geterror(char message[SIR_MAXERROR]);
 
@@ -150,10 +150,10 @@ uint16_t sir_geterror(char message[SIR_MAXERROR]);
  * the same thread that encountered a failed library call be the one to retrieve
  * the error message.
  *
- * @param err Pointer to a ::sir_errinfo structure into which the error infor-
+ * @param err Pointer to a ::sir_errorinfo structure into which the error infor-
  *            mation is placed.
  */
-void sir_geterrorinfo(sir_errinfo* err);
+void sir_geterrorinfo(sir_errorinfo* err);
 
 /**
  * @brief Dispatches a ::SIRL_DEBUG level message.

--- a/include/sir.hh
+++ b/include/sir.hh
@@ -382,9 +382,21 @@ namespace sir
      * @class std_format_adapter
      * @brief Adapter for std::format (when available).
      *
-     * TODO: update description
+     * Enabled when std::format is available on this platform and SIR_NO_STD_FORMAT
+     * is not defined.
      *
-     * @tparam TPolicy policy A derived class of policy which controls the behavior
+     * Allows for the use of std::format in place of (or in addition to) C-style
+     * variadic argument methods.
+     *
+     * **Example:**
+     *
+     * ~~~
+     * using my_logger = logger<true, default_policy, std_format_adapter>;
+     * my_logger log;
+     * log.info_std("This is from {}!", "std::format");
+     * ~~~
+     *
+     * @tparam TPolicy A derived class of policy which controls the behavior
      * of logger and by association, its adapters.
      */
     template<DerivedFromPolicy TPolicy>

--- a/include/sir.hh
+++ b/include/sir.hh
@@ -634,11 +634,23 @@ namespace sir
      * @class std_iostream_adapter
      * @brief Provides a std::iostream interface to libsir's logging functions.
      *
+     * Enabled so long as SIR_NO_STD_IOSTREAM is not defined.
+     *
      * Implements a public std::ostream member for each available logging level
      * (e.g. debug_stream, info_stream, ..., emerg_stream).
      *
+     * **Example:**
+     *
+     * ~~~
+     * using my_logger = logger<true, default_policy, std_iostream_adapter>;
+     * my_logger log;
+     * log.info_stream << "This is from std::iostream!" << std::endl;
+     * ~~~
+     *
+     * @see std_iostream_logger
+     *
      * @note Use std::endl or std::flush to indicate the end of a log message if
-     * using the iostream << operator.
+     * using the ostream << operator.
      *
      * @tparam TPolicy A derived class of policy which controls the behavior
      * of logger and by association, its adapters.

--- a/include/sir.hh
+++ b/include/sir.hh
@@ -238,10 +238,10 @@ namespace sir
      * adapter can coexist with any other adapters that are applied to the logger
      * template.
      *
-     * @see ::std_format_adapter
-     * @see ::boost_format_adapter
-     * @see ::fmt_format_adapter
-     * @see ::std_iostream_adapter
+     * @see std_format_adapter
+     * @see boost_format_adapter
+     * @see fmt_format_adapter
+     * @see std_iostream_adapter
      */
     class adapter {
     protected:

--- a/include/sir.hh
+++ b/include/sir.hh
@@ -787,14 +787,16 @@ namespace sir
      * Instantiate this class in order to access libsir with all the benefits
      * of C++, including RAII initialization/cleanup, custom adapters, and more.
      *
-     * @tparam RAII      Set to `true` to enable 'resource acquisition is
-     *                  initialization' behavior (i.e., libsir is initialized by
-     *                  the ctor, and cleaned up by the dtor). Set to `false` for
-     *                  manual management of initialization/cleanup.
+     * @see default_logger
+     *
+     * @tparam RAII      Set to true to enable 'resource acquisition is
+     *                   initialization' behavior (i.e., libsir is initialized by
+     *                   the ctor, and cleaned up by the dtor). Set to false for
+     *                   manual management of initialization/cleanup.
      * @tparam TPolicy   A policy class which will be responsible for certain
-     *                  aspects of logger's behavior.
+     *                   aspects of logger's behavior.
      * @tparam TAdapters One or more adapter classes whose public methods will be
-     *                  exposed by this class.
+     *                   exposed by this class.
      */
     template<bool RAII, DerivedFromPolicy TPolicy, template<class> class ...TAdapters>
     requires DerivedFromT<adapter, TAdapters<TPolicy>...>
@@ -965,6 +967,11 @@ namespace sir
     using default_logger = logger<true, default_policy, default_adapter>;
 
 # if defined(__SIR_HAVE_STD_FORMAT__)
+    /**
+     * @typedef std_format_logger
+     * @brief A logger that implements the default adapter and the std::format
+     * adapter.
+     */
     using std_format_logger = logger
     <
         true,
@@ -975,6 +982,11 @@ namespace sir
 # endif
 
 # if defined(__SIR_HAVE_BOOST_FORMAT__)
+    /**
+     * @typedef boost_logger
+     * @brief A logger that implements the default adapter and the boost::format
+     * adapter.
+     */
     using boost_logger = logger
     <
         true,
@@ -985,6 +997,11 @@ namespace sir
 # endif
 
 # if defined(__SIR_HAVE_FMT_FORMAT__)
+    /**
+     * @typedef fmt_logger
+     * @brief A logger that implements the default adapter and the fmt::format
+     * adapter.
+     */
     using fmt_logger = logger
     <
         true,
@@ -995,6 +1012,11 @@ namespace sir
 # endif
 
 # if !defined(SIR_NO_STD_IOSTREAM)
+    /**
+     * @typedef iostream_logger
+     * @brief A logger that implements the default adapter and the std::iostream
+     * adapter.
+     */
     using iostream_logger = logger
     <
         true,

--- a/include/sir.hh
+++ b/include/sir.hh
@@ -396,6 +396,8 @@ namespace sir
      * log.info_std("This is from {}!", "std::format");
      * ~~~
      *
+     * @see std_format_logger
+     *
      * @tparam TPolicy A derived class of policy which controls the behavior
      * of logger and by association, its adapters.
      */
@@ -538,9 +540,23 @@ namespace sir
 # if defined(__SIR_HAVE_FMT_FORMAT__)
     /**
      * @class fmt_format_adapter
-     * @brief Adapter for fmt (when available).
+     * @brief Adapter for {fmt} (when available).
      *
-     * TODO: update description
+     * Enabled when {fmt} is available on this platform and SIR_NO_FMT_FORMAT is
+     * not defined.
+     *
+     * Allows for the use of fmt::format in place of (or in addition to) C-style
+     * variadic argument methods.
+     *
+     * **Example:**
+     *
+     * ~~~
+     * using my_logger = logger<true, default_policy, fmt_format_adapter>;
+     * my_logger log;
+     * log.info_fmt("This is from {}}!", "fmt::format"));
+     * ~~~
+     *
+     * @see fmt_logger
      *
      * @tparam TPolicy A derived class of policy which controls the behavior
      * of logger and by association, its adapters.

--- a/include/sir.hh
+++ b/include/sir.hh
@@ -267,10 +267,10 @@ namespace sir
      * in place requires throwing an exception, retrieves the associated error
      * code and message from libsir, then throws.
      *
-     * @tparam TPolicy policy A derived class of policy which determines whether
+     * @tparam TPolicy A derived class of policy which determines whether
      * or not to throw exceptions upon encountering an error.
      *
-     * @param expr bool An expression that is evaluated against false. If false,
+     * @param expr An expression that is evaluated against false. If false,
      *  an error is determined to have occurred and an exception will be thrown
      * if the policy requires it.
      *
@@ -295,7 +295,7 @@ namespace sir
      * Utilizes the same code path that the C interface itself does, in order to
      * achieve maximum performance (i.e., no unnecessary bloat is added).
      *
-     * @tparam TPolicy policy A derived class of policy which controls the behavior
+     * @tparam TPolicy A derived class of policy which controls the behavior
      * of logger and by association, its adapters.
      */
     template<DerivedFromPolicy TPolicy>
@@ -458,7 +458,7 @@ namespace sir
      *
      * TODO: update description
      *
-     * @tparam TPolicy policy A derived class of policy which controls the behavior
+     * @tparam TPolicy A derived class of policy which controls the behavior
      * of logger and by association, its adapters.
      */
     template<DerivedFromPolicy TPolicy>
@@ -516,7 +516,7 @@ namespace sir
      *
      * TODO: update description
      *
-     * @tparam TPolicy policy A derived class of policy which controls the behavior
+     * @tparam TPolicy A derived class of policy which controls the behavior
      * of logger and by association, its adapters.
      */
     template<DerivedFromPolicy TPolicy>
@@ -598,7 +598,7 @@ namespace sir
      * @note Use std::endl or std::flush to indicate the end of a log message if
      * using the iostream << operator.
      *
-     * @tparam TPolicy policy A derived class of policy which controls the behavior
+     * @tparam TPolicy A derived class of policy which controls the behavior
      * of logger and by association, its adapters.
      */
     template<DerivedFromPolicy TPolicy>

--- a/include/sir.hh
+++ b/include/sir.hh
@@ -113,7 +113,7 @@ namespace sir
         std::string os_message; /**< If an OS/libc error, the associated message. */
 
         static error_info from_last_error() {
-            sir_errinfo errinfo {};
+            sir_errorinfo errinfo {};
             sir_geterrorinfo(&errinfo);
             return { { errinfo.code, errinfo.msg }, errinfo.func, errinfo.file,
                 errinfo.line, errinfo.os_code, errinfo.os_msg };

--- a/include/sir.hh
+++ b/include/sir.hh
@@ -71,19 +71,18 @@ namespace sir
 {
     /**
      * @struct error
-     * @brief Contains a numeric error code and formatted error message.
+     * @brief Contains basic information about an error.
      *
-     * Provides the default libsir error message formatting. In the event that
-     * the default error message formatting is undesirable, or to access more
-     * information about an error, use error_info.
+     * Provides the default error message formatting (SIR_ERRORFORMAT). In
+     * the event that the default formatting is undesirable, or to obtain
+     * additional information about an error, use the error_info struct.
      *
      * @see SIR_ERRORFORMAT
-     * @see sir_errorcode
      * @see error_info
      */
     struct error {
-        uint16_t code {};    /**< libsir error code (see ::sir_errorcode). */
-        std::string message; /**< Message describing the error that occurred. */
+        uint16_t code {};    /**< Numeric error code (see sir_errorcode). */
+        std::string message; /**< Formatted error message. */
 
         constexpr bool is_os_error() const noexcept {
             return code == SIR_E_PLATFORM;
@@ -98,11 +97,11 @@ namespace sir
 
     /**
      * @struct error_info
-     * @brief Contains granular information about an error.
+     * @brief Contains all available information about an error.
      *
      * Provides extended information about an error that occurred in order to
      * allow for custom error handling. If the numeric error code and default
-     * error message formatting are sufficient, use error instead.
+     * error message formatting are sufficient, use the error struct instead.
      *
      * @see error
      */
@@ -282,7 +281,7 @@ namespace sir
      * in place requires throwing an exception, retrieves the associated error
      * code and message from libsir, then throws.
      *
-     * @param TPolicy policy A derived class of policy which determines whether
+     * @tparam TPolicy policy A derived class of policy which determines whether
      * or not to throw exceptions upon encountering an error.
      *
      * @param expr bool An expression that is evaluated against false. If false,
@@ -310,7 +309,7 @@ namespace sir
      * Utilizes the same code path that the C interface itself does, in order to
      * achieve maximum performance (i.e., no unnecessary bloat is added).
      *
-     * @param TPolicy policy A derived class of policy which controls the behavior
+     * @tparam TPolicy policy A derived class of policy which controls the behavior
      * of logger and by association, its adapters.
      */
     template<DerivedFromPolicy TPolicy>
@@ -399,7 +398,7 @@ namespace sir
      *
      * TODO: update description
      *
-     * @param TPolicy policy A derived class of policy which controls the behavior
+     * @tparam TPolicy policy A derived class of policy which controls the behavior
      * of logger and by association, its adapters.
      */
     template<DerivedFromPolicy TPolicy>
@@ -473,7 +472,7 @@ namespace sir
      *
      * TODO: update description
      *
-     * @param TPolicy policy A derived class of policy which controls the behavior
+     * @tparam TPolicy policy A derived class of policy which controls the behavior
      * of logger and by association, its adapters.
      */
     template<DerivedFromPolicy TPolicy>
@@ -531,7 +530,7 @@ namespace sir
      *
      * TODO: update description
      *
-     * @param TPolicy policy A derived class of policy which controls the behavior
+     * @tparam TPolicy policy A derived class of policy which controls the behavior
      * of logger and by association, its adapters.
      */
     template<DerivedFromPolicy TPolicy>
@@ -613,7 +612,7 @@ namespace sir
      * @note Use std::endl or std::flush to indicate the end of a log message if
      * using the iostream << operator.
      *
-     * @param TPolicy policy A derived class of policy which controls the behavior
+     * @tparam TPolicy policy A derived class of policy which controls the behavior
      * of logger and by association, its adapters.
      */
     template<DerivedFromPolicy TPolicy>
@@ -748,13 +747,13 @@ namespace sir
      * Instantiate this class in order to access libsir with all the benefits
      * of C++, including RAII initialization/cleanup, custom adapters, and more.
      *
-     * @param RAII      Set to `true` to enable 'resource acquisition is
+     * @tparam RAII      Set to `true` to enable 'resource acquisition is
      *                  initialization' behavior (i.e., libsir is initialized by
      *                  the ctor, and cleaned up by the dtor). Set to `false` for
      *                  manual management of initialization/cleanup.
-     * @param TPolicy   A policy class which will be responsible for certain
+     * @tparam TPolicy   A policy class which will be responsible for certain
      *                  aspects of logger's behavior.
-     * @param TAdapters One or more adapter classes whose public methods will be
+     * @tparam TAdapters One or more adapter classes whose public methods will be
      *                  exposed by this class.
      */
     template<bool RAII, DerivedFromPolicy TPolicy, template<class> class ...TAdapters>

--- a/include/sir.hh
+++ b/include/sir.hh
@@ -468,7 +468,21 @@ namespace sir
      * @class boost_format_adapter
      * @brief Adapter for boost::format (when available).
      *
-     * TODO: update description
+     * Enabled when boost::format is available on this platform and
+     * SIR_NO_BOOST_FORMAT is not defined.
+     *
+     * Allows for the use of boost::format in place of (or in addition to)
+     * C-style variadic argument methods.
+     *
+     * **Example:**
+     *
+     * ~~~
+     * using my_logger = logger<true, default_policy, boost_format_adapter>;
+     * my_logger log;
+     * log.info_bf(boost::format("This is from %1%!" % "boost::format"));
+     * ~~~
+     *
+     * @see boost_logger
      *
      * @tparam TPolicy A derived class of policy which controls the behavior
      * of logger and by association, its adapters.
@@ -479,42 +493,42 @@ namespace sir
         boost_format_adapter() = default;
         ~boost_format_adapter() override = default;
 
-        bool debug_boost(const boost::format& fmt) const {
+        bool debug_bf(const boost::format& fmt) const {
             const bool ret = sir_debug("%s", fmt.str().c_str());
             return throw_on_policy<TPolicy>(ret);
         }
 
-        bool info_boost(const boost::format& fmt) const {
+        bool info_bf(const boost::format& fmt) const {
             const bool ret = sir_info("%s", fmt.str().c_str());
             return throw_on_policy<TPolicy>(ret);
         }
 
-        bool notice_boost(const boost::format& fmt) const {
+        bool notice_bf(const boost::format& fmt) const {
             const bool ret = sir_notice("%s", fmt.str().c_str());
             return throw_on_policy<TPolicy>(ret);
         }
 
-        bool warn_boost(const boost::format& fmt) const {
+        bool warn_bf(const boost::format& fmt) const {
             const bool ret = sir_warn("%s", fmt.str().c_str());
             return throw_on_policy<TPolicy>(ret);
         }
 
-        bool error_boost(const boost::format& fmt) const {
+        bool error_bf(const boost::format& fmt) const {
             const bool ret = sir_error("%s", fmt.str().c_str());
             return throw_on_policy<TPolicy>(ret);
         }
 
-        bool crit_boost(const boost::format& fmt) const {
+        bool crit_bf(const boost::format& fmt) const {
             const bool ret = sir_crit("%s", fmt.str().c_str());
             return throw_on_policy<TPolicy>(ret);
         }
 
-        bool alert_boost(const boost::format& fmt) const {
+        bool alert_bf(const boost::format& fmt) const {
             const bool ret = sir_alert("%s", fmt.str().c_str());
             return throw_on_policy<TPolicy>(ret);
         }
 
-        bool emerg_boost(const boost::format& fmt) const {
+        bool emerg_bf(const boost::format& fmt) const {
             const bool ret = sir_emerg("%s", fmt.str().c_str());
             return throw_on_policy<TPolicy>(ret);
         }

--- a/include/sir.hh
+++ b/include/sir.hh
@@ -751,6 +751,7 @@ namespace sir
             return sir_isinitialized();
         }
 
+        // TODO: split error into two types. add get_error_info
         error get_error() const {
             std::array<char, SIR_MAXERROR> message {};
             const auto code = sir_geterror(message.data());

--- a/include/sir/errors.h
+++ b/include/sir/errors.h
@@ -85,7 +85,7 @@ uint16_t _sir_geterrcode(uint32_t err) {
 }
 
 /** Internal error codes. */
-# define _SIR_E_NOERROR   SIR_E_NOERROR
+# define _SIR_E_NOERROR   _sir_mkerror(SIR_E_NOERROR)
 # define _SIR_E_NOTREADY  _sir_mkerror(SIR_E_NOTREADY)
 # define _SIR_E_ALREADY   _sir_mkerror(SIR_E_ALREADY)
 # define _SIR_E_DUPITEM   _sir_mkerror(SIR_E_DUPITEM)

--- a/include/sir/errors.h
+++ b/include/sir/errors.h
@@ -85,7 +85,7 @@ uint16_t _sir_geterrcode(uint32_t err) {
 }
 
 /** Internal error codes. */
-# define _SIR_E_NOERROR   _sir_mkerror(SIR_E_NOERROR) //-V616
+# define _SIR_E_NOERROR   _sir_mkerror(SIR_E_NOERROR)
 # define _SIR_E_NOTREADY  _sir_mkerror(SIR_E_NOTREADY)
 # define _SIR_E_ALREADY   _sir_mkerror(SIR_E_ALREADY)
 # define _SIR_E_DUPITEM   _sir_mkerror(SIR_E_DUPITEM)

--- a/include/sir/errors.h
+++ b/include/sir/errors.h
@@ -35,29 +35,29 @@
 
 /** Error codes. */
 enum sir_errorcode {
-    SIR_E_NOERROR   = 0,    /**< The operation completed successfully */
-    SIR_E_NOTREADY  = 1,    /**< libsir has not been initialized */
-    SIR_E_ALREADY   = 2,    /**< libsir is already initialized */
-    SIR_E_DUPITEM   = 3,    /**< Item already managed by libsir */
-    SIR_E_NOITEM    = 4,    /**< Item not managed by libsir */
-    SIR_E_NOROOM    = 5,    /**< Maximum number of items already stored */
-    SIR_E_OPTIONS   = 6,    /**< Option flags are invalid */
-    SIR_E_LEVELS    = 7,    /**< Level flags are invalid */
-    SIR_E_TEXTSTYLE = 8,    /**< Text style is invalid */
-    SIR_E_STRING    = 9,    /**< Invalid string argument */
-    SIR_E_NULLPTR   = 10,   /**< NULL pointer argument */
-    SIR_E_INVALID   = 11,   /**< Invalid argument */
-    SIR_E_NODEST    = 12,   /**< No destinations registered for level */
-    SIR_E_UNAVAIL   = 13,   /**< Feature is disabled or unavailable */
-    SIR_E_INTERNAL  = 14,   /**< An internal error has occurred */
-    SIR_E_COLORMODE = 15,   /**< Color mode is invalid */
-    SIR_E_TEXTATTR  = 16,   /**< Text attributes are invalid */
-    SIR_E_TEXTCOLOR = 17,   /**< Text color is invalid for mode */
-    SIR_E_PLUGINBAD = 18,   /**< Plugin module is malformed */
-    SIR_E_PLUGINDAT = 19,   /**< Data produced by plugin is invalid */
-    SIR_E_PLUGINVER = 20,   /**< Plugin interface version unsupported */
-    SIR_E_PLUGINERR = 21,   /**< Plugin reported failure */
-    SIR_E_PLATFORM  = 22,   /**< Platform error code %%d: %%s */
+    SIR_E_NOERROR   = 1,    /**< The operation completed successfully */
+    SIR_E_NOTREADY  = 2,    /**< libsir has not been initialized */
+    SIR_E_ALREADY   = 3,    /**< libsir is already initialized */
+    SIR_E_DUPITEM   = 4,    /**< Item already managed by libsir */
+    SIR_E_NOITEM    = 5,    /**< Item not managed by libsir */
+    SIR_E_NOROOM    = 6,    /**< Maximum number of items already stored */
+    SIR_E_OPTIONS   = 7,    /**< Option flags are invalid */
+    SIR_E_LEVELS    = 8,    /**< Level flags are invalid */
+    SIR_E_TEXTSTYLE = 9,    /**< Text style is invalid */
+    SIR_E_STRING    = 10,    /**< Invalid string argument */
+    SIR_E_NULLPTR   = 11,   /**< NULL pointer argument */
+    SIR_E_INVALID   = 12,   /**< Invalid argument */
+    SIR_E_NODEST    = 13,   /**< No destinations registered for level */
+    SIR_E_UNAVAIL   = 14,   /**< Feature is disabled or unavailable */
+    SIR_E_INTERNAL  = 15,   /**< An internal error has occurred */
+    SIR_E_COLORMODE = 16,   /**< Color mode is invalid */
+    SIR_E_TEXTATTR  = 17,   /**< Text attributes are invalid */
+    SIR_E_TEXTCOLOR = 18,   /**< Text color is invalid for mode */
+    SIR_E_PLUGINBAD = 19,   /**< Plugin module is malformed */
+    SIR_E_PLUGINDAT = 20,   /**< Data produced by plugin is invalid */
+    SIR_E_PLUGINVER = 21,   /**< Plugin interface version unsupported */
+    SIR_E_PLUGINERR = 22,   /**< Plugin reported failure */
+    SIR_E_PLATFORM  = 23,   /**< Platform error code %%d: %%s */
     SIR_E_UNKNOWN   = 4095, /**< Unknown error */
 };
 
@@ -85,7 +85,7 @@ uint16_t _sir_geterrcode(uint32_t err) {
 }
 
 /** Internal error codes. */
-# define _SIR_E_NOERROR   _sir_mkerror(SIR_E_NOERROR)
+# define _SIR_E_NOERROR   _sir_mkerror(SIR_E_NOERROR) //-V616
 # define _SIR_E_NOTREADY  _sir_mkerror(SIR_E_NOTREADY)
 # define _SIR_E_ALREADY   _sir_mkerror(SIR_E_ALREADY)
 # define _SIR_E_DUPITEM   _sir_mkerror(SIR_E_DUPITEM)

--- a/include/sir/errors.h
+++ b/include/sir/errors.h
@@ -133,7 +133,7 @@ bool __sir_handlewin32err(DWORD code, const char* func, const char* file, uint32
 uint32_t _sir_geterror(char message[SIR_MAXERROR]);
 
 /** Returns information about the last error that occurred on the calling thread. */
-void _sir_geterrorinfo(sir_errinfo* err);
+void _sir_geterrorinfo(sir_errorinfo* err);
 
 /** Resets TLS error information. */
 void _sir_reset_tls_error(void);

--- a/include/sir/errors.h
+++ b/include/sir/errors.h
@@ -85,7 +85,7 @@ uint16_t _sir_geterrcode(uint32_t err) {
 }
 
 /** Internal error codes. */
-# define _SIR_E_NOERROR   _sir_mkerror(SIR_E_NOERROR)
+# define _SIR_E_NOERROR   SIR_E_NOERROR
 # define _SIR_E_NOTREADY  _sir_mkerror(SIR_E_NOTREADY)
 # define _SIR_E_ALREADY   _sir_mkerror(SIR_E_ALREADY)
 # define _SIR_E_DUPITEM   _sir_mkerror(SIR_E_DUPITEM)
@@ -110,14 +110,13 @@ uint16_t _sir_geterrcode(uint32_t err) {
 # define _SIR_E_PLATFORM  _sir_mkerror(SIR_E_PLATFORM)
 # define _SIR_E_UNKNOWN   _sir_mkerror(SIR_E_UNKNOWN)
 
-//-V:_sir_seterror:616
 bool __sir_seterror(uint32_t err, const char* func, const char* file, uint32_t line);
 # define _sir_seterror(err) __sir_seterror(err, __func__, __file__, __LINE__)
 
 void __sir_setoserror(int code, const char* msg, const char* func,
     const char* file, uint32_t line);
 
-/** Handle a C library error. */
+/** Handle an OS/libc error. */
 bool __sir_handleerr(int code, const char* func, const char* file, uint32_t line);
 # define _sir_handleerr(code) __sir_handleerr(code, __func__, __file__, __LINE__)
 
@@ -125,17 +124,16 @@ bool __sir_handleerr(int code, const char* func, const char* file, uint32_t line
 void _sir_invalidparameter(const wchar_t* expr, const wchar_t* func, const wchar_t* file,
     unsigned int line, uintptr_t reserved);
 
-/**
- * Some Win32 API error codes overlap C library error codes, so they need to be handled separately.
- * Mapping them sounds great, but in practice, valuable information about what went wrong is totally
- * lost in translation.
- */
 bool __sir_handlewin32err(DWORD code, const char* func, const char* file, uint32_t line);
 #  define _sir_handlewin32err(code) __sir_handlewin32err((DWORD)code, __func__, __file__, __LINE__)
 # endif
 
-/** Returns information about the last error that occurred. */
+/** Retrieves a formatted message for the last error that occurred on the calling
+ * thread and returns the associated internal error code. */
 uint32_t _sir_geterror(char message[SIR_MAXERROR]);
+
+/** Returns information about the last error that occurred on the calling thread. */
+void _sir_geterrorinfo(sir_errinfo* err);
 
 /** Resets TLS error information. */
 void _sir_reset_tls_error(void);

--- a/include/sir/types.h
+++ b/include/sir/types.h
@@ -144,10 +144,10 @@ typedef struct {
     const char* func;          /**< Name of the function in which the error occurred. */
     const char* file;          /**< Name of the file in which the error occurred. */
     uint32_t line;             /**< Line number at which the error occurred. */
-    int os_code;               /**< If an OS/libc error, the associated code. */
-    char os_msg[SIR_MAXERROR]; /**< If an OS/libc error, the associated message. */
-    uint16_t code;             /**< libsir error code. */
-    char msg[SIR_MAXERROR];    /**< libsir error message. */
+    int os_code;               /**< If an OS/libc error, the relevant code. */
+    char os_msg[SIR_MAXERROR]; /**< If an OS/libc error, the relevant message. */
+    uint16_t code;             /**< Numeric error code (see ::sir_errorcode). */
+    char msg[SIR_MAXERROR];    /**< Error message associated with code. */
 } sir_errinfo;
 
 /**

--- a/include/sir/types.h
+++ b/include/sir/types.h
@@ -134,7 +134,7 @@ enum {
 typedef uint32_t sir_textcolor;
 
 /**
- * @struct sir_errinfo
+ * @struct sir_errorinfo
  * @brief Information about an error that occurred.
  *
  * Granular error information in order to provide the caller with flexibility in
@@ -148,7 +148,7 @@ typedef struct {
     char os_msg[SIR_MAXERROR]; /**< If an OS/libc error, the relevant message. */
     uint16_t code;             /**< Numeric error code (see ::sir_errorcode). */
     char msg[SIR_MAXERROR];    /**< Error message associated with code. */
-} sir_errinfo;
+} sir_errorinfo;
 
 /**
  * @struct sir_textstyle

--- a/include/sir/types.h
+++ b/include/sir/types.h
@@ -134,6 +134,23 @@ enum {
 typedef uint32_t sir_textcolor;
 
 /**
+ * @struct sir_error
+ * @brief Information about an error that occurred.
+ *
+ * Granular error information in order to provide the caller with flexibility in
+ * regards to error handling and formatting.
+*/
+typedef struct {
+    const char* func;          /**< Function name. */
+    const char* file;          /**< File name. */
+    uint32_t line;             /**< Line number. */
+    int os_code;               /**< If an OS/libc error, the associated code. */
+    char os_msg[SIR_MAXERROR]; /**< If an OS/libc error, the associated message. */
+    uint16_t code;             /**< libsir error code. */
+    char msg[SIR_MAXERROR];    /**< libsir error message. */
+} sir_errinfo;
+
+/**
  * @struct sir_textstyle
  * @brief Container for all the information associated with the appearance of text
  * in the context of stdio.
@@ -284,12 +301,6 @@ typedef struct {
     } state;
 } sirconfig;
 
-/** Internally-used error type. */
-typedef struct {
-    uint32_t code;
-    const char* const message;
-} sirerror;
-
 /** Internally-used log file data. */
 typedef struct {
     const char* path;
@@ -434,8 +445,8 @@ typedef enum {
 /** Per-thread error type. */
 typedef struct {
     uint32_t lasterror;
-    int os_error;
-    char os_errmsg[SIR_MAXERROR];
+    int os_code;
+    char os_msg[SIR_MAXERROR];
 
     struct {
         const char* func;

--- a/include/sir/types.h
+++ b/include/sir/types.h
@@ -141,9 +141,9 @@ typedef uint32_t sir_textcolor;
  * regards to error handling and formatting.
 */
 typedef struct {
-    const char* func;          /**< Function name. */
-    const char* file;          /**< File name. */
-    uint32_t line;             /**< Line number. */
+    const char* func;          /**< Name of the function in which the error occurred. */
+    const char* file;          /**< Name of the file in which the error occurred. */
+    uint32_t line;             /**< Line number at which the error occurred. */
     int os_code;               /**< If an OS/libc error, the associated code. */
     char os_msg[SIR_MAXERROR]; /**< If an OS/libc error, the associated message. */
     uint16_t code;             /**< libsir error code. */

--- a/include/sir/types.h
+++ b/include/sir/types.h
@@ -134,7 +134,7 @@ enum {
 typedef uint32_t sir_textcolor;
 
 /**
- * @struct sir_error
+ * @struct sir_errinfo
  * @brief Information about an error that occurred.
  *
  * Granular error information in order to provide the caller with flexibility in

--- a/src/sir.c
+++ b/src/sir.c
@@ -54,6 +54,10 @@ uint16_t sir_geterror(char message[SIR_MAXERROR]) {
     return _sir_geterrcode(_sir_geterror(message));
 }
 
+void sir_geterrorinfo(sir_errinfo* err) {
+    _sir_geterrorinfo(err);
+}
+
 PRINTF_FORMAT_ATTR(1, 2)
 bool sir_debug(PRINTF_FORMAT const char* format, ...) {
     _SIR_L_START(format);

--- a/src/sir.c
+++ b/src/sir.c
@@ -54,7 +54,7 @@ uint16_t sir_geterror(char message[SIR_MAXERROR]) {
     return _sir_geterrcode(_sir_geterror(message));
 }
 
-void sir_geterrorinfo(sir_errinfo* err) {
+void sir_geterrorinfo(sir_errorinfo* err) {
     _sir_geterrorinfo(err);
 }
 

--- a/src/sirerrors.c
+++ b/src/sirerrors.c
@@ -51,7 +51,8 @@ static _sir_thread_local sir_thread_err _sir_te = {
     _SIR_E_NOERROR, 0, {0}, {SIR_UNKNOWN, SIR_UNKNOWN, 0}
 };
 
-#define _SIR_E_PLATFORM_ERRORFORMAT "Platform error code %d: %s"
+#define _SIR_E_PLATFORM_ERRORMSG "Platform error"
+#define _SIR_E_PLATFORM_ERRORFORMAT _SIR_E_PLATFORM_ERRORMSG " code %d: %s"
 
 static const struct {
     uint32_t e;
@@ -255,8 +256,11 @@ void _sir_geterrorinfo(sir_errinfo* err) {
     _SIR_BEGIN_BIN_SEARCH()
 
     if (sir_errors[_mid].e == _sir_te.lasterror) {
-        err->code = _sir_geterrcode(_sir_te.lasterror);
-        (void)_sir_strncpy(err->msg, SIR_MAXERROR, sir_errors[_mid].msg, SIR_MAXERROR);
+        err->code = _sir_geterrcode(sir_errors[_mid].e);
+        if (_SIR_E_PLATFORM == sir_errors[_mid].e)
+            (void)_sir_strncpy(err->msg, SIR_MAXERROR, _SIR_E_PLATFORM_ERRORMSG, SIR_MAXERROR);
+        else
+            (void)_sir_strncpy(err->msg, SIR_MAXERROR, sir_errors[_mid].msg, SIR_MAXERROR);
         break;
     }
 

--- a/src/sirerrors.c
+++ b/src/sirerrors.c
@@ -48,7 +48,7 @@
 
 /** Per-thread error data */
 static _sir_thread_local sir_thread_err _sir_te = {
-    _SIR_E_NOERROR, 0, {0}, {SIR_UNKNOWN, SIR_UNKNOWN, 0} //-V616
+    _SIR_E_NOERROR, 0, {0}, {SIR_UNKNOWN, SIR_UNKNOWN, 0}
 };
 
 #define _SIR_E_PLATFORM_ERRORFORMAT "Platform error code %d: %s"
@@ -57,7 +57,7 @@ static const struct {
     uint32_t e;
     const char* msg;
 } sir_errors[] = {
-    {_SIR_E_NOERROR,   "The operation completed successfully"}, //-V616
+    {_SIR_E_NOERROR,   "The operation completed successfully"},
     {_SIR_E_NOTREADY,  "libsir has not been initialized"},
     {_SIR_E_ALREADY,   "libsir is already initialized"},
     {_SIR_E_DUPITEM,   "Item already managed by libsir"},
@@ -89,25 +89,28 @@ bool __sir_seterror(uint32_t err, const char* func, const char* file, uint32_t l
         _sir_te.loc.func  = func;
         _sir_te.loc.file  = file;
         _sir_te.loc.line  = line;
+
+        if (_SIR_E_PLATFORM != err) {
+            _sir_te.os_code = 0;
+            _sir_resetstr(_sir_te.os_msg);
+        }
     }
 #if defined(DEBUG) && defined(SIR_SELFLOG)
-    if (_SIR_E_NOERROR != err) { //-V616
+    if (_SIR_E_NOERROR != err) {
         char errmsg[SIR_MAXERROR] = {0};
-        uint32_t code             = _sir_geterror(errmsg);
-        SIR_UNUSED(code);
+        _sir_geterror(errmsg);
         __sir_selflog(func, file, line, "%s", errmsg);
     }
 #endif
     return false;
 }
 
-void __sir_setoserror(int code, const char* msg, const char* func, const char* file,
-    uint32_t line) {
-    _sir_te.os_error = code;
-    _sir_resetstr(_sir_te.os_errmsg);
+void __sir_setoserror(int code, const char* msg, const char* func, const char* file, uint32_t line) {
+    _sir_te.os_code = code;
+    _sir_resetstr(_sir_te.os_msg);
 
     if (_sir_validstrnofail(msg))
-        _sir_strncpy(_sir_te.os_errmsg, SIR_MAXERROR, msg, SIR_MAXERROR);
+        _sir_strncpy(_sir_te.os_msg, SIR_MAXERROR, msg, SIR_MAXERROR);
 
     (void)__sir_seterror(_SIR_E_PLATFORM, func, file, line);
 }
@@ -207,8 +210,8 @@ uint32_t _sir_geterror(char message[SIR_MAXERROR]) {
         if (_SIR_E_PLATFORM == sir_errors[_mid].e) {
             heap_msg = calloc(SIR_MAXERROR, sizeof(char));
             if (_sir_validptrnofail(heap_msg)) {
-                _sir_snprintf_trunc(heap_msg, SIR_MAXERROR, _SIR_E_PLATFORM_ERRORFORMAT, _sir_te.os_error,
-                    (_sir_validstrnofail(_sir_te.os_errmsg) ? _sir_te.os_errmsg : SIR_UNKNOWN));
+                _sir_snprintf_trunc(heap_msg, SIR_MAXERROR, _SIR_E_PLATFORM_ERRORFORMAT, _sir_te.os_code,
+                    (_sir_validstrnofail(_sir_te.os_msg) ? _sir_te.os_msg : SIR_UNKNOWN));
             }
         }
 
@@ -229,10 +232,42 @@ uint32_t _sir_geterror(char message[SIR_MAXERROR]) {
     return retval;
 }
 
+void _sir_geterrorinfo(sir_errinfo* err) {
+    if (!_sir_validptr(err))
+        return;
+
+    memset(err, 0, sizeof(sir_errinfo));
+
+    err->func = _sir_te.loc.func;
+    err->file = _sir_te.loc.file;
+    err->line = _sir_te.loc.line;
+
+    err->os_code = _sir_te.os_code;
+    (void)_sir_strncpy(err->os_msg, SIR_MAXERROR, (_sir_validstrnofail(_sir_te.os_msg)
+        ? _sir_te.os_msg : SIR_UNKNOWN), SIR_MAXERROR);
+
+    err->code = _sir_geterrcode(SIR_E_UNKNOWN);
+
+    static const size_t low  = 0;
+    static const size_t high = _sir_countof(sir_errors) - 1;
+
+    _SIR_DECLARE_BIN_SEARCH(low, high);
+    _SIR_BEGIN_BIN_SEARCH()
+
+    if (sir_errors[_mid].e == _sir_te.lasterror) {
+        err->code = _sir_geterrcode(_sir_te.lasterror);
+        (void)_sir_strncpy(err->msg, SIR_MAXERROR, sir_errors[_mid].msg, SIR_MAXERROR);
+        break;
+    }
+
+    _SIR_ITERATE_BIN_SEARCH((sir_errors[_mid].e < _sir_te.lasterror ? 1 : -1));
+    _SIR_END_BIN_SEARCH();
+}
+
 void _sir_reset_tls_error(void) {
-    _sir_te.lasterror = _SIR_E_NOERROR; //-V616
-    _sir_te.os_error  = 0;
-    _sir_resetstr(_sir_te.os_errmsg);
+    _sir_te.lasterror = _SIR_E_NOERROR;
+    _sir_te.os_code  = 0;
+    _sir_resetstr(_sir_te.os_msg);
     _sir_te.loc.func = SIR_UNKNOWN;
     _sir_te.loc.file = SIR_UNKNOWN;
     _sir_te.loc.line = 0U;

--- a/src/sirerrors.c
+++ b/src/sirerrors.c
@@ -233,11 +233,11 @@ uint32_t _sir_geterror(char message[SIR_MAXERROR]) {
     return retval;
 }
 
-void _sir_geterrorinfo(sir_errinfo* err) {
+void _sir_geterrorinfo(sir_errorinfo* err) {
     if (!_sir_validptr(err))
         return;
 
-    memset(err, 0, sizeof(sir_errinfo));
+    memset(err, 0, sizeof(sir_errorinfo));
 
     err->func = _sir_te.loc.func;
     err->file = _sir_te.loc.file;

--- a/tests/tests++.cc
+++ b/tests/tests++.cc
@@ -208,15 +208,17 @@ bool sir::tests::error_handling() {
 
     auto print_error = [&log]() {
         TEST_MSG_0("get error with logger::get_error...");
-        const auto [ code, message ] = log.get_error();
-        TEST_MSG("error: code = %" PRIu16 ", message = '%s'", code, message.c_str());
+        const auto err = log.get_error();
+        TEST_MSG("error: os error = %s, code = %" PRIu16 ", message = '%s'",
+            (err.is_os_error() ? "yes" : "no"), err.code, err.message.c_str());
     };
 
     auto print_error_info = [&log]() {
         TEST_MSG_0("get error information with logger::get_error_info...");
         const auto errinfo = log.get_error_info();
-        TEST_MSG("error info: code = %" PRIu16 ", message = '%s', function = '%s',"
-            " file = '%s', line = %" PRIu32 ", OS code = %d, OS message = '%s'",
+        TEST_MSG("error info: os error = %s, code = %" PRIu16 ", message = '%s',"
+            " function = '%s', file = '%s', line = %" PRIu32 ", OS code = %d,"
+            " OS message = '%s'", (errinfo.is_os_error() ? "yes" : "no"),
             errinfo.code, errinfo.message.c_str(), errinfo.func.c_str(),
             errinfo.file.c_str(), errinfo.line, errinfo.os_code,
             errinfo.os_message.c_str());

--- a/tests/tests++.cc
+++ b/tests/tests++.cc
@@ -244,7 +244,7 @@ bool sir::tests::error_handling() {
 }
 
 bool sir::tests::exception_handling() {
-    bool pass = true;
+    _SIR_TEST_COMMENCE
 
     try {
         TEST_MSG_0("throw a sir::exception with a string message...");
@@ -271,7 +271,26 @@ bool sir::tests::exception_handling() {
         _sir_eqland(pass, _sir_validstrnofail(ex.what()));
     }
 
-    return PRINT_RESULT_RETURN(pass);
+    /* ensure that exceptions are not thrown with a policy that does not
+     * enable exceptions. */
+    class nothrow_policy : public default_policy {
+    public:
+        nothrow_policy() = default;
+        ~nothrow_policy() override = default;
+
+        static constexpr bool throw_on_error() noexcept {
+            return false;
+        }
+    };
+
+    TEST_MSG_0("create a logger with a no-throw policy...");
+    logger<true, nothrow_policy, default_adapter> log;
+
+    TEST_MSG_0("created; call a method that would normally throw...");
+    _sir_eqland(pass, !log.load_plugin(""));
+    TEST_MSG_0("if you can read this, no exception was thrown");
+
+    _SIR_TEST_COMPLETE
 }
 
 bool sir::tests::std_format() {

--- a/tests/tests++.cc
+++ b/tests/tests++.cc
@@ -321,14 +321,14 @@ bool sir::tests::boost_format() {
 #if defined(__SIR_HAVE_BOOST_FORMAT__)
     using bf = boost::format;
     boost_logger log;
-    _sir_eqland(pass, log.debug_boost(bf("Testing %1% %2%")  % "boost" % "Howdy"));
-    _sir_eqland(pass, log.info_boost(bf("Testing %1% %2%")   % "boost" % true));
-    _sir_eqland(pass, log.notice_boost(bf("Testing %1% %2%") % "boost" % (1.0 / 1e9)));
-    _sir_eqland(pass, log.warn_boost(bf("Testing %1% %2%")   % "boost" % std::to_string(123456789)));
-    _sir_eqland(pass, log.error_boost(bf("Testing %1% %2%")  % "boost" % std::numeric_limits<uint64_t>::max()));
-    _sir_eqland(pass, log.crit_boost(bf("Testing %1% %2%")   % "boost" % 0b10101010));
-    _sir_eqland(pass, log.alert_boost(bf("Testing %1% %2%")  % "boost" % 0x80000000U));
-    _sir_eqland(pass, log.emerg_boost(bf("Testing %1% %2%")  % "boost" % 3.14));
+    _sir_eqland(pass, log.debug_bf(bf("Testing %1% %2%")  % "boost" % "Howdy"));
+    _sir_eqland(pass, log.info_bf(bf("Testing %1% %2%")   % "boost" % true));
+    _sir_eqland(pass, log.notice_bf(bf("Testing %1% %2%") % "boost" % (1.0 / 1e9)));
+    _sir_eqland(pass, log.warn_bf(bf("Testing %1% %2%")   % "boost" % std::to_string(123456789)));
+    _sir_eqland(pass, log.error_bf(bf("Testing %1% %2%")  % "boost" % std::numeric_limits<uint64_t>::max()));
+    _sir_eqland(pass, log.crit_bf(bf("Testing %1% %2%")   % "boost" % 0b10101010));
+    _sir_eqland(pass, log.alert_bf(bf("Testing %1% %2%")  % "boost" % 0x80000000U));
+    _sir_eqland(pass, log.emerg_bf(bf("Testing %1% %2%")  % "boost" % 3.14));
 #else
     TEST_MSG_0(EMPH(BBLUE("boost::format support not enabled; skipping")));
 #endif // !__SIR_HAVE_BOOST_FORMAT__

--- a/tests/tests++.hh
+++ b/tests/tests++.hh
@@ -116,11 +116,16 @@ namespace sir::tests
     bool pass = true; \
     try {
 
-/** Implements recovery in the event that an exception is caught. */
-# define _SIR_TEST_ON_EXCEPTION(excpt) \
-    ERROR_MSG("exception in %s: '%s'", __PRETTY_FUNCTION__, excpt); \
+/** Implements recovery in the event that an unexpected exception is caught. */
+# define _SIR_TEST_ON_EXCEPTION(what) \
+    ERROR_MSG("unexpected exception in %s: '%s'", __PRETTY_FUNCTION__, what); \
     pass = false; \
-    (void)sir_cleanup()
+    if (sir_isinitialized()) \
+        (void)sir_cleanup()
+
+/** Handles an expected exception. */
+# define _SIR_TEST_ON_EXPECTED_EXCEPTION(what) \
+    TEST_MSG(GREEN("expected exception in %s: '%s'"), __PRETTY_FUNCTION__, what)
 
 /** Ends a test by closing the try/catch block and implementing exception handling. */
 # define _SIR_TEST_COMPLETE \

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -827,7 +827,7 @@ bool sirtest_errorsanity(void) {
         _sir_eqland(pass, _sir_validstrnofail(errinfo.msg));
 
         if (errinfo.code == SIR_E_PLATFORM) {
-            _sir_eqland(pass, errinfo.code != 0);
+            _sir_eqland(pass, errinfo.os_code != 0);
             _sir_eqland(pass, _sir_validstrnofail(errinfo.os_msg));
         }
     }

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -813,7 +813,7 @@ bool sirtest_errorsanity(void) {
 
         /* ensure that sir_geterrorinfo agrees with sir_geterror, and
          * that it returns sane data. */
-        sir_errinfo errinfo = {0};
+        sir_errorinfo errinfo = {0};
         sir_geterrorinfo(&errinfo);
 
         TEST_MSG("errinfo = {'%s', '%s', %"PRIu32", %"PRIu16", '%s', %d, '%s'}",

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -803,6 +803,8 @@ bool sirtest_errorsanity(void) {
         {SIR_E_UNKNOWN,   "SIR_E_UNKNOWN"},   /**< Unknown error (4095) */
     };
 
+    // TODO: add test for geterrorinfo.
+
     char message[SIR_MAXERROR] = {0};
     for (size_t n = 0; n < _sir_countof(errors); n++) {
         (void)_sir_seterror(_sir_mkerror(errors[n].code));
@@ -2323,7 +2325,7 @@ void os_log_child_activity(void* ctx) {
 bool filter_error(bool pass, uint16_t err) {
     if (!pass) {
         char msg[SIR_MAXERROR] = {0};
-        if (sir_geterror(msg) != err)
+        if (sir_geterror(msg) != err) // TODO: use sir_geterror
             return false;
     }
     return true;

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -777,29 +777,29 @@ bool sirtest_errorsanity(void) {
         uint16_t code;
         const char* name;
     } errors[] = {
-        {SIR_E_NOERROR,   "SIR_E_NOERROR"},   /**< The operation completed successfully (0) */
-        {SIR_E_NOTREADY,  "SIR_E_NOTREADY"},  /**< libsir has not been initialized (1) */
-        {SIR_E_ALREADY,   "SIR_E_ALREADY"},   /**< libsir is already initialized (2) */
-        {SIR_E_DUPITEM,   "SIR_E_DUPITEM"},   /**< Item already managed by libsir (3) */
-        {SIR_E_NOITEM,    "SIR_E_NOITEM"},    /**< Item not managed by libsir (4) */
-        {SIR_E_NOROOM,    "SIR_E_NOROOM"},    /**< Maximum number of items already stored (5) */
-        {SIR_E_OPTIONS,   "SIR_E_OPTIONS"},   /**< Option flags are invalid (6) */
-        {SIR_E_LEVELS,    "SIR_E_LEVELS"},    /**< Level flags are invalid (7) */
-        {SIR_E_TEXTSTYLE, "SIR_E_TEXTSTYLE"}, /**< Text style is invalid (8) */
-        {SIR_E_STRING,    "SIR_E_STRING"},    /**< Invalid string argument (9) */
-        {SIR_E_NULLPTR,   "SIR_E_NULLPTR"},   /**< NULL pointer argument (10) */
-        {SIR_E_INVALID,   "SIR_E_INVALID"},   /**< Invalid argument (11) */
-        {SIR_E_NODEST,    "SIR_E_NODEST"},    /**< No destinations registered for level (12) */
-        {SIR_E_UNAVAIL,   "SIR_E_UNAVAIL"},   /**< Feature is disabled or unavailable (13) */
-        {SIR_E_INTERNAL,  "SIR_E_INTERNAL"},  /**< An internal error has occurred (14) */
-        {SIR_E_COLORMODE, "SIR_E_COLORMODE"}, /**< Invalid color mode (15) */
-        {SIR_E_TEXTATTR,  "SIR_E_TEXTATTR"},  /**< Invalid text attributes (16) */
-        {SIR_E_TEXTCOLOR, "SIR_E_TEXTCOLOR"}, /**< Invalid text color (17) */
-        {SIR_E_PLUGINBAD, "SIR_E_PLUGINBAD"}, /**< Plugin module is malformed (18) */
-        {SIR_E_PLUGINDAT, "SIR_E_PLUGINDAT"}, /**< Data produced by plugin is invalid (19) */
-        {SIR_E_PLUGINVER, "SIR_E_PLUGINVER"}, /**< Plugin interface version unsupported (20) */
-        {SIR_E_PLUGINERR, "SIR_E_PLUGINERR"}, /**< Plugin reported failure (21) */
-        {SIR_E_PLATFORM,  "SIR_E_PLATFORM"},  /**< Platform error code %d: %s (22) */
+        {SIR_E_NOERROR,   "SIR_E_NOERROR"},   /**< The operation completed successfully (1) */
+        {SIR_E_NOTREADY,  "SIR_E_NOTREADY"},  /**< libsir has not been initialized (2) */
+        {SIR_E_ALREADY,   "SIR_E_ALREADY"},   /**< libsir is already initialized (3) */
+        {SIR_E_DUPITEM,   "SIR_E_DUPITEM"},   /**< Item already managed by libsir (4) */
+        {SIR_E_NOITEM,    "SIR_E_NOITEM"},    /**< Item not managed by libsir (5) */
+        {SIR_E_NOROOM,    "SIR_E_NOROOM"},    /**< Maximum number of items already stored (6) */
+        {SIR_E_OPTIONS,   "SIR_E_OPTIONS"},   /**< Option flags are invalid (7) */
+        {SIR_E_LEVELS,    "SIR_E_LEVELS"},    /**< Level flags are invalid (8) */
+        {SIR_E_TEXTSTYLE, "SIR_E_TEXTSTYLE"}, /**< Text style is invalid (9) */
+        {SIR_E_STRING,    "SIR_E_STRING"},    /**< Invalid string argument (10) */
+        {SIR_E_NULLPTR,   "SIR_E_NULLPTR"},   /**< NULL pointer argument (11) */
+        {SIR_E_INVALID,   "SIR_E_INVALID"},   /**< Invalid argument (12) */
+        {SIR_E_NODEST,    "SIR_E_NODEST"},    /**< No destinations registered for level (13) */
+        {SIR_E_UNAVAIL,   "SIR_E_UNAVAIL"},   /**< Feature is disabled or unavailable (14) */
+        {SIR_E_INTERNAL,  "SIR_E_INTERNAL"},  /**< An internal error has occurred (15) */
+        {SIR_E_COLORMODE, "SIR_E_COLORMODE"}, /**< Invalid color mode (16) */
+        {SIR_E_TEXTATTR,  "SIR_E_TEXTATTR"},  /**< Invalid text attributes (17) */
+        {SIR_E_TEXTCOLOR, "SIR_E_TEXTCOLOR"}, /**< Invalid text color (18) */
+        {SIR_E_PLUGINBAD, "SIR_E_PLUGINBAD"}, /**< Plugin module is malformed (19) */
+        {SIR_E_PLUGINDAT, "SIR_E_PLUGINDAT"}, /**< Data produced by plugin is invalid (20) */
+        {SIR_E_PLUGINVER, "SIR_E_PLUGINVER"}, /**< Plugin interface version unsupported (21) */
+        {SIR_E_PLUGINERR, "SIR_E_PLUGINERR"}, /**< Plugin reported failure (22) */
+        {SIR_E_PLATFORM,  "SIR_E_PLATFORM"},  /**< Platform error code %d: %s (23) */
         {SIR_E_UNKNOWN,   "SIR_E_UNKNOWN"},   /**< Unknown error (4095) */
     };
 

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -805,7 +805,13 @@ bool sirtest_errorsanity(void) {
 
     char message[SIR_MAXERROR] = {0};
     for (size_t n = 0; n < _sir_countof(errors); n++) {
-        (void)_sir_seterror(_sir_mkerror(errors[n].code));
+        if (SIR_E_PLATFORM == errors[n].code) {
+            /* cause an actual platform error. */
+            (void)sir_addfile("invalid/file!name", SIRL_ALL, SIRO_DEFAULT);
+        } else {
+            (void)_sir_seterror(_sir_mkerror(errors[n].code));
+        }
+
         memset(message, 0, SIR_MAXERROR);
         uint16_t err = sir_geterror(message);
         _sir_eqland(pass, errors[n].code == err && *message != '\0');
@@ -821,14 +827,17 @@ bool sirtest_errorsanity(void) {
             errinfo.os_code, errinfo.os_msg);
 
         _sir_eqland(pass, errinfo.code == err);
-        _sir_eqland(pass, _sir_strsame(__func__, errinfo.func, strlen(__func__)));
-        _sir_eqland(pass, _sir_strsame(__file__, errinfo.file, SIR_MAXPATH));
         _sir_eqland(pass, errinfo.line != 0U);
         _sir_eqland(pass, _sir_validstrnofail(errinfo.msg));
 
         if (errinfo.code == SIR_E_PLATFORM) {
             _sir_eqland(pass, errinfo.os_code != 0);
             _sir_eqland(pass, _sir_validstrnofail(errinfo.os_msg));
+            _sir_eqland(pass, _sir_validstrnofail(errinfo.func));
+            _sir_eqland(pass, _sir_validstrnofail(errinfo.file));
+        } else {
+            _sir_eqland(pass, _sir_strsame(__func__, errinfo.func, strlen(__func__)));
+            _sir_eqland(pass, _sir_strsame(__file__, errinfo.file, SIR_MAXPATH));
         }
     }
 

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -816,7 +816,7 @@ bool sirtest_errorsanity(void) {
         sir_errinfo errinfo = {0};
         sir_geterrorinfo(&errinfo);
 
-        TEST_MSG("errinfo = {'%s', '%s', %"PRId32", %"PRId16", '%s', %d, '%s'}",
+        TEST_MSG("errinfo = {'%s', '%s', %"PRIu32", %"PRIu16", '%s', %d, '%s'}",
             errinfo.func, errinfo.file, errinfo.line, errinfo.code, errinfo.msg,
             errinfo.os_code, errinfo.os_msg);
 


### PR DESCRIPTION
In the event that a caller is not satisfied with (or is otherwise precluded from using) the default error message formatting, we're adding `sir_geterrorinfo` (and associated C++ types/methods).

This allows for the retrieval of all of the information about the error, piecemeal:

* function name
* file name
* line number
* libsir error code
* libsir error message
* OS/libc error code
* OS/libc error message

> I also got a bit sidetracked, forgot I was on this branch for one purpose and started editing doxgyen C++ comments... 😬 

Closes #295.