### PR TITLE
Use `SIR_NO_FMT_FORMAT=1` and `SIR_NO_BOOST_FORMAT=1` for Coverity submission build.

### DIFF
--- a/.coverity.sh
+++ b/.coverity.sh
@@ -211,7 +211,7 @@ printf '%s\n' '#### Notice: Building libsir for Coverity analysis.'
 make clean &&                                 \
 env TZ=UTC PATH="./.coverity/bin:${PATH:?}"   \
     ./.coverity/bin/cov-build --dir "cov-int" \
-      make all tests++
+      make all tests++ SIR_NO_FMT_FORMAT=1 SIR_NO_BOOST_FORMAT=1
 
 ##############################################################################
 


### PR DESCRIPTION
* Use `SIR_NO_FMT_FORMAT=1` and `SIR_NO_BOOST_FORMAT=1` for Coverity submission build.