### PR TITLE
Minor CI tweaks

### DIFF
--- a/.coverity.sh
+++ b/.coverity.sh
@@ -208,10 +208,14 @@ tar zxf "${COVERITY_DLDIR:?}/coverity_tool.tgz"                  \
 ##############################################################################
 
 printf '%s\n' '#### Notice: Building libsir for Coverity analysis.'
-make clean &&                                 \
-env TZ=UTC PATH="./.coverity/bin:${PATH:?}"   \
-    ./.coverity/bin/cov-build --dir "cov-int" \
-      make all tests++ SIR_NO_FMT_FORMAT=1 SIR_NO_BOOST_FORMAT=1
+make clean &&                                     \
+env TZ=UTC                                        \
+    PATH="./.coverity/bin:${PATH:?}"              \
+    CXXFLAGS="-DSIR_NO_FMT_FORMAT=1               \
+              -DSIR_NO_BOOST_FORMAT=1             \
+              -DSIR_NO_STD_FORMAT=1"              \
+        ./.coverity/bin/cov-build --dir "cov-int" \
+            make all tests++
 
 ##############################################################################
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3224,6 +3224,7 @@ Linux/x86_64 (AOCC, Fedora Python):
 
 Semgrep (Cloud Rules):
   allow_failure: true
+  timeout: 15 minutes
   tags:
     - Docker-x64
     - Linux
@@ -3253,6 +3254,7 @@ Semgrep (Cloud Rules):
 
 Semgrep (GitLab Rules):
   allow_failure: true
+  timeout: 15 minutes
   tags:
     - Docker-x64
     - Linux

--- a/.lint.sh
+++ b/.lint.sh
@@ -462,9 +462,10 @@ test_cppcheck()
       rm -f ./cppcheck.xml
       mkdir -p cppcheck; ret="${?}"
       test "${ret}" -ne 0 && exit 99
-      # shellcheck disable=SC2046
+      # shellcheck disable=SC2046,SC2155
       export EXTRA_INCLUDES="$(gcc -Wp,-v -x c++ - -fsyntax-only < /dev/null 2>&1 | grep '^ /' | sed 's/^ /-I/' | awk '{ print $1 }')" || \
           export EXTRA_INCLUDES="-I/usr/include"
+      # shellcheck disable=SC2086,SC2046
       cppcheck \
       ${EXTRA_INCLUDES:-I/usr/include} \
       --enable="all" \
@@ -540,6 +541,7 @@ test_pvs()
   # shellcheck disable=SC2140
   printf '%s\n' "set -e;" > ./.extra.sh
   ret="${?}"; test "${ret:-0}" -eq 99 && exit 99
+  # shellcheck disable=SC2140
   eval ./build/bin/mcmb "${SIR_OPTIONS:?}" | xargs -I{} \
     printf '%s\n' "export PVS_FLAGS=\""{}"\";./.lint.sh pvs_real" | \
     sort -u >> ./.extra.sh


### PR DESCRIPTION
* Exempt scanning some third-party dependencies with Coverity
* Appease ShellCheck on `.lint.sh`
* Use 15 minute timeout for Semgrep jobs