### PR TITLE
Fix: file name splitting with `./` prefix

### DIFF
--- a/src/sirfilecache.c
+++ b/src/sirfilecache.c
@@ -322,7 +322,7 @@ bool _sirfile_splitpath(const sirfile* sf, char** name, char** ext) {
             return _sir_handleerr(errno);
 
         const char* lastfullstop = strrchr(tmp, '.');
-        if (lastfullstop) {
+        if (lastfullstop && lastfullstop != tmp) {
             uintptr_t namesize = lastfullstop - tmp;
             SIR_ASSERT(namesize < SIR_MAXPATH);
 
@@ -336,6 +336,7 @@ bool _sirfile_splitpath(const sirfile* sf, char** name, char** ext) {
             _sir_strncpy(*name, namesize + 1, tmp, namesize);
             *ext = strndup(sf->path + namesize, strnlen(sf->path + namesize, SIR_MAXPATH));
         } else {
+            lastfullstop = NULL;
             *name = strndup(sf->path, strnlen(sf->path, SIR_MAXPATH));
         }
 

--- a/src/sirfilecache.c
+++ b/src/sirfilecache.c
@@ -270,8 +270,8 @@ void _sirfile_rollifneeded(sirfile* sf) {
         bool rolled   = false;
         char* newpath = NULL;
 
-        _sir_selflog("file (path: '%s', id: %"PRIx32") reached ~%d bytes"
-            " in size; rolling...", sf->path, sf->id, SIR_FROLLSIZE);
+        _sir_selflog("file (path: '%s', id: %"PRIx32") reached ~%d bytes in size;"
+            " rolling...", sf->path, sf->id, SIR_FROLLSIZE);
 
         _sir_fflush(sf->f);
 
@@ -283,8 +283,8 @@ void _sirfile_rollifneeded(sirfile* sf) {
 
         _sir_safefree(&newpath);
         if (!rolled) /* write anyway; don't want to lose data. */
-            _sir_selflog("error: failed to roll file (path: '%s', id: %"
-                PRIx32")!", sf->path, sf->id);
+            _sir_selflog("error: failed to roll file (path: '%s', id: %"PRIx32")!",
+                sf->path, sf->id);
     }
 }
 

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -962,10 +962,6 @@ bool sirtest_textstylesanity(void) {
     return PRINT_RESULT_RETURN(pass);
 }
 
-#if defined(__clang__) && !defined(__EMBARCADEROC__)
-/* only Clang has implicit-conversion; GCC BZ#87454 */
-SANITIZE_SUPPRESS("implicit-conversion")
-#endif
 bool sirtest_optionssanity(void) {
     INIT(si, SIRL_ALL, 0, 0, 0);
     bool pass = si_init;
@@ -1060,7 +1056,7 @@ bool sirtest_optionssanity(void) {
     }
 
     /* greater than SIRO_NOHDR. */
-    invalid = (0xFFFF0000 & ~SIRO_NOHDR); /* implicit-conversion */
+    invalid = (0xFFFF0000 & ~SIRO_NOHDR);
     _sir_eqland(pass, !_sir_validopts(invalid));
     printf(INDENT_ITEM WHITE("greater than SIRO_NOHDR: %08"PRIx32) "\n", invalid);
 

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -2384,7 +2384,7 @@ void os_log_child_activity(void* ctx) {
 bool filter_error(bool pass, uint16_t err) {
     if (!pass) {
         char msg[SIR_MAXERROR] = {0};
-        if (sir_geterror(msg) != err) // TODO: use sir_geterror
+        if (sir_geterror(msg) != err)
             return false;
     }
     return true;

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -679,21 +679,21 @@ bool sirtest_failwithoutinit(void) {
 }
 
 bool sirtest_isinitialized(void) {
-    // TODO: replace printfs with TEST_MSG_0 after python branch is merged in.
+
     bool pass = true;
 
-    (void)printf("\tchecking sir_isinitialized before initialization...");
+    TEST_MSG_0("checking sir_isinitialized before initialization...");
     _sir_eqland(pass, !sir_isinitialized());
 
     INIT(si, SIRL_ALL, 0, 0, 0);
     _sir_eqland(pass, si_init);
 
-    (void)printf("\tchecking sir_isinitialized after initialization...");
+    TEST_MSG_0("checking sir_isinitialized after initialization...");
     _sir_eqland(pass, sir_isinitialized());
 
     _sir_eqland(pass, sir_cleanup());
 
-    (void)printf("\tchecking sir_isinitialized after cleanup...");
+    TEST_MSG_0("checking sir_isinitialized after cleanup...");
     _sir_eqland(pass, !sir_isinitialized());
 
     return PRINT_RESULT_RETURN(pass);


### PR DESCRIPTION
* File names beginning with ./ would fail to be rolled/archived because the file name splitting routine used left of `.` as the name part, and right as extension; in this case, the name part is empty, and so the routine returns false