### PR TITLE
Special file system handling for PASE

### DIFF
--- a/.lint.sh
+++ b/.lint.sh
@@ -504,7 +504,7 @@ test_cppcheck()
       # shellcheck disable=SC2086,SC2046
       cppcheck \
       ${EXTRA_INCLUDES:-I/usr/include} \
-      --enable="all,style,performance" \
+      --enable="all" \
       --inline-suppr \
       --inconclusive \
       --library=posix \
@@ -512,12 +512,9 @@ test_cppcheck()
       --suppress=*:/Applications/* \
       --suppress=badBitmaskCheck:include/sir/defaults.h \
       --suppress=comparisonError:tests/tests.c \
-      --suppress=constVariablePointer \
-      --suppress=cstyleCast \
       --suppress=*:/Library/Developer/* \
       --suppress=missingIncludeSystem \
       --suppress=readdirCalled \
-      --suppress=redundantAssignment \
       --suppress=knownConditionTrueFalse \
       --suppress=unmatchedSuppression \
       --suppress=unreadVariable \

--- a/.lint.sh
+++ b/.lint.sh
@@ -504,8 +504,9 @@ test_cppcheck()
       # shellcheck disable=SC2086,SC2046
       cppcheck \
       ${EXTRA_INCLUDES:-I/usr/include} \
-      --enable="all" \
+      --enable="all,style,performance" \
       --inline-suppr \
+      --inconclusive \
       --library=posix \
       --platform=unix64 \
       --suppress=*:/Applications/* \
@@ -517,12 +518,10 @@ test_cppcheck()
       --suppress=missingIncludeSystem \
       --suppress=readdirCalled \
       --suppress=redundantAssignment \
-      --suppress=shadowFunction \
       --suppress=knownConditionTrueFalse \
       --suppress=unmatchedSuppression \
       --suppress=unreadVariable \
       --suppress=*:/usr/include/* \
-      --suppress=variableScope \
       -DCLOCK_REALTIME=1 \
       -DCLOCK_MONOTONIC=6 \
       -D_POSIX_TIMERS=2 \

--- a/autoformat.sh
+++ b/autoformat.sh
@@ -61,8 +61,9 @@ run_cppi()
   printf '%s' "Formatting with cppi ..."
   ( # shellcheck disable=SC2038
     find . -name "*.[ch]" -o -name "*.cc" -o -name "*.hh" | \
-      xargs -I{} "${SHELL:-sh}" -c \
-        'set -e; cppi "{}" > "{}.cppi" && mv -f "{}.cppi" "{}"'
+      grep -Ev '(mcmb\.c|\.git/.*)' | \
+        xargs -I{} "${SHELL:-sh}" -c \
+          'set -e; cppi "{}" > "{}.cppi" && mv -f "{}.cppi" "{}"'
   ) && printf '%s\n' "complete."
 }
 

--- a/autoformat.sh
+++ b/autoformat.sh
@@ -58,7 +58,7 @@ test -f "./${0##*/}" > /dev/null 2>&1 || {
 
 run_cppi()
 {
-  printf '%s' "Formatting with cppi ..."
+  printf '%s' "Formatting with cppi ... "
   ( # shellcheck disable=SC2038
     find . -name "*.[ch]" -o -name "*.cc" -o -name "*.hh" | \
       grep -Ev '(mcmb\.c|\.git/.*)' | \

--- a/include/sir/filesystem.h
+++ b/include/sir/filesystem.h
@@ -85,11 +85,15 @@ ssize_t _sir_readlink(const char* restrict path, char* restrict buf, size_t bufs
 # endif
 
 # if defined(_AIX)
-int _sir_aixself(char *buffer, size_t *size);
+int _sir_aixself(char* buffer, size_t* size);
 # endif
 
 # if defined(__OpenBSD__)
-int _sir_openbsdself(char* out, int capacity, int* dirname_length);
+int _sir_openbsdself(char* buffer, int size);
+# endif
+
+# if defined(__OpenBSD__) || (defined(_AIX) && defined(__PASE__))
+int _sir_resolvepath(const char* restrict path, char* restrict buffer, size_t size);
 # endif
 
 # if defined(__cplusplus)

--- a/include/sir/platform.h
+++ b/include/sir/platform.h
@@ -457,6 +457,7 @@ _set_thread_local_invalid_parameter_handler(
 #   define SIR_NO_THREAD_NAMES
 #  endif
 #  if defined(_AIX)
+#   include <procinfo.h>
 #   include <sys/procfs.h>
 #   include <sys/systemcfg.h>
 #   undef SIR_NO_THREAD_NAMES

--- a/include/sir/threadpool.h
+++ b/include/sir/threadpool.h
@@ -37,7 +37,7 @@
 
 # define SIR_THREADPOOL_MAX_THREADS 386
 
-bool _sir_threadpool_create(sir_threadpool** pool, size_t num);
+bool _sir_threadpool_create(sir_threadpool** pool, size_t num_threads);
 bool _sir_threadpool_add_job(sir_threadpool* pool, sir_threadpool_job* job);
 bool _sir_threadpool_destroy(sir_threadpool** pool);
 

--- a/src/sirfilecache.c
+++ b/src/sirfilecache.c
@@ -58,7 +58,7 @@ bool _sir_updatefile(sirfileid id, const sir_update_config_data* data) {
     if (!_sir_sanity() || !_sir_validfileid(id) || !_sir_validupdatedata(data))
         return false;
 
-    _SIR_LOCK_SECTION(sirfcache, sfc, SIRMI_FILECACHE, false);
+    _SIR_LOCK_SECTION(const sirfcache, sfc, SIRMI_FILECACHE, false);
     bool retval = _sir_fcache_update(sfc, id, data);
     _SIR_UNLOCK_SECTION(SIRMI_FILECACHE);
 
@@ -138,16 +138,16 @@ bool _sirfile_write(sirfile* sf, const char* output) {
         }
 
         size_t writeLen = strnlen(output, SIR_MAXOUTPUT);
-        size_t write    = fwrite(output, sizeof(char), writeLen, sf->f);
+        size_t wrote    = fwrite(output, sizeof(char), writeLen, sf->f);
 
-        SIR_ASSERT(write == writeLen);
+        SIR_ASSERT(wrote == writeLen);
 
-        if (write < writeLen) {
+        if (wrote < writeLen) {
             (void)_sir_handleerr(errno);
             clearerr(sf->f);
         }
 
-        retval = write == writeLen;
+        retval = wrote == writeLen;
     }
 
     return retval;
@@ -600,7 +600,7 @@ bool _sir_fcache_dispatch(const sirfcache* sfc, sir_level level, sirbuf* buf,
                   _sir_validptr(wanted);
 
     if (retval) {
-        const char* write    = NULL;
+        const char* wrote    = NULL;
         sir_options lastopts = 0U;
 
         *dispatched = 0;
@@ -619,13 +619,13 @@ bool _sir_fcache_dispatch(const sirfcache* sfc, sir_level level, sirbuf* buf,
 
             (*wanted)++;
 
-            if (!write || sfc->files[n]->opts != lastopts) {
-                write = _sir_format(false, sfc->files[n]->opts, buf);
-                SIR_ASSERT(write);
+            if (!wrote || sfc->files[n]->opts != lastopts) {
+                wrote = _sir_format(false, sfc->files[n]->opts, buf);
+                SIR_ASSERT(wrote);
                 lastopts = sfc->files[n]->opts;
             }
 
-            if (write && _sirfile_write(sfc->files[n], write)) {
+            if (wrote && _sirfile_write(sfc->files[n], wrote)) {
                 (*dispatched)++;
             } else {
                 _sir_selflog("error: write to file (path: '%s', id: %"PRIx32") failed!",

--- a/src/sirfilesystem.c
+++ b/src/sirfilesystem.c
@@ -242,14 +242,14 @@ char* _sir_getappfilename(void) {
 
 #if !defined(__WIN__)
 # if defined(__READLINK_OS__)
-        ssize_t read = _sir_readlink(PROC_SELF, buffer, size - 1);
-        if (-1L != read && read < (ssize_t)size - 1) {
+        ssize_t rdlink = _sir_readlink(PROC_SELF, buffer, size - 1);
+        if (-1L != rdlink && rdlink < (ssize_t)size - 1) {
             resolved = true;
             break;
-        } else if (-1L == read) {
+        } else if (-1L == rdlink) {
             resolved = _sir_handleerr(errno);
             break;
-        } else if (read == (ssize_t)size - 1L) {
+        } else if (rdlink == (ssize_t)size - 1L) {
             /* it is possible that truncation occurred. as a security
              * precaution, fail; someone may have tampered with the link. */
             _sir_selflog("warning: readlink reported truncation; not using result!");
@@ -376,10 +376,10 @@ char* _sir_getappdir(void) {
     }
 
     const char* retval = _sir_getdirname(filename);
-    char* dirname = strndup(retval, strnlen(retval, SIR_MAXPATH));
+    char* dname = strndup(retval, strnlen(retval, SIR_MAXPATH));
 
     _sir_safefree(&filename);
-    return dirname;
+    return dname;
 }
 
 char* _sir_getbasename(char* restrict path) {

--- a/src/sirfilesystem.c
+++ b/src/sirfilesystem.c
@@ -77,13 +77,25 @@ bool _sir_pathgetstat(const char* restrict path, struct stat* restrict st, sir_r
 #  error "unknown open_flags for your platform; please contact the developers."
 # endif
 
-        int fd = (rel_to == SIR_PATH_REL_TO_CWD) ? AT_FDCWD : open(base_path, open_flags);
+# if !(defined(_AIX) || !defined(__PASE__))
+        int fd = open(base_path, open_flags);
         if (-1 == fd) {
             _sir_safefree(&base_path);
             return _sir_handleerr(errno);
         }
-
         stat_ret = fstatat(fd, path, st, AT_SYMLINK_NOFOLLOW);
+# else
+        // HACKHACK: fstatat does not work properly for any fd other than AT_FDCWD.
+        SIR_UNUSED(open_flags);
+        int fd = AT_FDCWD;
+        if (rel_to == SIR_PATH_REL_TO_CWD) {
+            stat_ret = fstatat(fd, path, st, AT_SYMLINK_NOFOLLOW);
+        } else if (rel_to == SIR_PATH_REL_TO_APP) {
+            char abs_path[SIR_MAXPATH] = {0};
+            (void)snprintf(abs_path, SIR_MAXPATH, "%s/%s", base_path, path);
+            stat_ret = stat(abs_path, st);
+        }
+# endif
         _sir_safeclose(&fd);
         _sir_safefree(&base_path);
     } else {
@@ -97,7 +109,6 @@ bool _sir_pathgetstat(const char* restrict path, struct stat* restrict st, sir_r
         /* Embarcadero <12 does not like paths that end in slashes, nor does it appreciate
          * paths like './' and '../'; this hack is needed for RAD Studio 11.3 and earlier. */
         char resolved_path[SIR_MAXPATH] = {0};
-
         if (!GetFullPathNameA(abs_path, SIR_MAXPATH, resolved_path, NULL)) {
             _sir_safefree(&base_path);
             return _sir_handlewin32err(GetLastError());
@@ -262,17 +273,10 @@ char* _sir_getappfilename(void) {
             continue;
         }
         int ret = _sir_aixself(buffer, &size);
-        if (ret == 0) {
-            resolved = true;
-            break;
-        } else {
-            resolved = _sir_handleerr(errno);
-            break;
-        }
+        resolved = ret == 0 ? true : _sir_handleerr(errno);
+        break;
 # elif defined(__OpenBSD__)
-        size_t length;
-        int dirname_length;
-        length = _sir_openbsdself(NULL, 0, &dirname_length);
+        size_t length = (size_t)_sir_openbsdself(NULL, 0);
         if (length < 1) {
             resolved = _sir_handleerr(errno);
             break;
@@ -281,12 +285,8 @@ char* _sir_getappfilename(void) {
             size = length + 1;
             continue;
         }
-        (void)_sir_openbsdself(buffer, length, &dirname_length);
-        if (!buffer) {
-            resolved = false;
-            break;
-        }
-        resolved = true;
+        (void)_sir_openbsdself(buffer, length);
+        resolved = _sir_validptrnofail(buffer);
         break;
 # elif defined(__BSD__)
         int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
@@ -440,6 +440,7 @@ bool _sir_getrelbasepath(const char* restrict path, bool* restrict relative,
 }
 
 #if defined(_AIX)
+# if !defined(__PASE__)
 # define SIR_MAXSLPATH (SIR_MAXPATH + 16)
 int _sir_aixself(char* buffer, size_t* size) {
     ssize_t res;
@@ -596,6 +597,42 @@ int _sir_aixself(char* buffer, size_t* size) {
         return -1;
     }
 }
+# elif defined(__PASE__)
+int _sir_aixself(char* buffer, size_t* size) {
+    struct procsinfo pinfo[16] = {0};
+    int numproc = 0;
+    int index = 0;
+    pid_t pid = _sir_getpid();
+    while ((numproc = getprocs(pinfo, sizeof(struct procsinfo), NULL, 0, &index, 16)) > 0) {
+        for (int n = 0; n < numproc; n++) {
+            if (pinfo[n].pi_state == SZOMB)
+                continue;
+            if (pinfo[n].pi_pid == pid) {
+                char tmp[SIR_MAXPATH + 2] = {0};
+                if (-1 == getargs(&pinfo[n], sizeof(struct procsinfo), tmp, sizeof(tmp))) {
+                    (void)_sir_handleerr(errno);
+                    break;
+                }
+                if (strchr(tmp, '/')) {
+                    char tmp2[SIR_MAXPATH] = {0};
+                    const char* rp = realpath(tmp, tmp2);
+                    if (!rp) {
+                        (void)_sir_handleerr(errno);
+                        break;
+                    }
+                    (void)_sir_strncpy(buffer, *size, tmp2, strnlen(tmp2, *size - 1));
+                } else {
+                    (void)_sir_resolvepath(tmp, buffer, *size);
+                }
+                if (_sir_validstrnofail(buffer))
+                    return 0;
+                break;
+            }
+        }
+    }
+    return -1;
+}
+# endif
 #endif
 
 bool _sir_deletefile(const char* restrict path) {
@@ -610,28 +647,27 @@ bool _sir_deletefile(const char* restrict path) {
 }
 
 #if defined(__OpenBSD__)
-int _sir_openbsdself(char* out, int capacity, int* dirname_length) {
+int _sir_openbsdself(char* buffer, int size) {
     char buffer1[4096];
     char buffer2[SIR_MAXPATH];
-    char buffer3[SIR_MAXPATH];
     char** argv    = (char**)buffer1;
     char* resolved = NULL;
     int length     = -1;
 
-    while (1) {
+    while (true) {
+        size_t mib_size = 0;
         int mib[4] = { CTL_KERN, KERN_PROC_ARGS, getpid(), KERN_PROC_ARGV };
-        size_t size;
 
-        if (sysctl(mib, 4, NULL, &size, NULL, 0) != 0)
+        if (sysctl(mib, 4, NULL, &mib_size, NULL, 0) != 0)
             break;
 
-        if (size > sizeof(buffer1)) {
-            argv = (char**)malloc(size);
+        if (mib_size > sizeof(buffer1)) {
+            argv = (char**)malloc(mib_size);
             if (!argv)
                 break;
         }
 
-        if (sysctl(mib, 4, argv, &size, NULL, 0) != 0)
+        if (sysctl(mib, 4, argv, &mib_size, NULL, 0) != 0)
             break;
 
         if (strchr(argv[0], '/')) {
@@ -639,52 +675,63 @@ int _sir_openbsdself(char* out, int capacity, int* dirname_length) {
             if (!resolved)
                 break;
         } else {
-            const char* PATH = getenv("PATH");
-            if (!PATH)
-                break;
-            size_t argv0_length = strnlen(argv[0], SIR_MAXPATH);
-            const char* begin   = PATH;
-            while (1) {
-                const char* separator = strchr(begin, ':');
-                const char* end = separator ? separator : begin + strnlen(begin, SIR_MAXPATH);
-                if (end - begin > 0) {
-                    if (*(end - 1) == '/')
-                        --end;
-                    if (((end - begin) + 1UL + argv0_length + 1UL) <= sizeof(buffer2)) {
-                        (void)memcpy(buffer2, begin, end - begin);
-                        buffer2[end - begin] = '/';
-                        (void)memcpy(buffer2 + (end - begin) + 1, argv[0], argv0_length + 1);
-                        resolved = realpath(buffer2, buffer3);
-                        if (resolved)
-                            break;
-                    }
-                }
-                if (!separator)
-                    break;
-                begin = ++separator;
-            }
+            if (-1 != _sir_resolvepath(argv[0], buffer2, sizeof(buffer2)))
+                resolved = buffer2;
             if (!resolved)
                 break;
         }
 
         length = (int)strnlen(resolved, SIR_MAXPATH);
-        if (length <= capacity) {
-            (void)memcpy(out, resolved, (unsigned long)length);
-            if (dirname_length) {
-                int i;
-                for (i = length - 1; i >= 0; --i) {
-                    if (out[i] == '/') {
-                        *dirname_length = i;
-                        break;
-                    }
-                }
-            }
-        }
+        if (length <= size)
+            (void)memcpy(buffer, resolved, (size_t)length);
         break;
     }
     if (argv != (char**)buffer1)
-        free(argv);
+        _sir_safefree(&argv);
 
     return length;
 }
 #endif
+
+# if defined(__OpenBSD__) || (defined(_AIX) && defined(__PASE__))
+int _sir_resolvepath(const char* restrict path, char* restrict buffer, size_t size) {
+    if (!_sir_validstr(path) || !_sir_validptr(buffer))
+        return -1;
+
+    const char* envvar = getenv("PATH");
+    if (!_sir_validstr(envvar))
+        return -1;
+
+    size_t pathlen         = strnlen(path, SIR_MAXPATH);
+    const char* cursor     = envvar;
+    char tmp[SIR_MAXPATH]  = {0};
+    char tmp2[SIR_MAXPATH] = {0};
+    int length             = -1;
+
+    while (true) {
+        const char* separator = strchr(cursor, ':');
+        const char* end = separator ? separator : cursor + strnlen(cursor, SIR_MAXPATH);
+        if (end - cursor > 0) {
+            if (*(end - 1) == '/')
+                --end;
+            if (((end - cursor) + 1UL + pathlen + 1UL) <= sizeof(tmp)) {
+                (void)memcpy(tmp, cursor, end - cursor);
+                tmp[end - cursor] = '/';
+                (void)memcpy(tmp + (end - cursor) + 1, path, pathlen + 1);
+                if (realpath(tmp, tmp2))
+                    break;
+            }
+        }
+        if (!separator)
+            break;
+        cursor = ++separator;
+    }
+
+    if (_sir_validstrnofail(tmp2)) {
+        length = (int)strnlen(tmp2, SIR_MAXPATH);
+        (void)_sir_strncpy(buffer, size, tmp2, (size_t)length);
+    }
+
+    return length;
+}
+# endif

--- a/src/sirhelpers.c
+++ b/src/sirhelpers.c
@@ -332,12 +332,12 @@ char* _sir_strremove(char *str, const char *sub) {
     if (!sub)
         return str;
 
-    const char* p;
     char* r;
     char* q;
 
     if (*sub && (q = r = strstr(str, sub)) != NULL) {
         size_t len = strnlen(sub, strlen(str));
+        const char* p;
 
         while ((r = strstr(p = r + len, sub)) != NULL)
             while (p < r)

--- a/src/sirinternal.c
+++ b/src/sirinternal.c
@@ -306,26 +306,28 @@ void _sir_reset_tls(void) {
 
 static
 bool _sir_updatelevels(const char* name, sir_levels* old, const sir_levels* new) {
-    bool retval = false;
-    if (*old != *new) {
-        _sir_selflog("updating %s levels from %04"PRIx16" to %04"PRIx16, name, *old, *new);
-        *old = *new;
-        retval = true;
-    } else {
-        _sir_selflog("skipped superfluous update of %s levels: %04"PRIx16, name, *old);
+    bool retval = _sir_validstr(name) && _sir_validptr(old) && _sir_validptr(new);
+    if (retval) {
+        if (*old != *new) {
+            _sir_selflog("updating %s levels from %04"PRIx16" to %04"PRIx16, name, *old, *new);
+            *old = *new;
+        } else {
+            _sir_selflog("skipped superfluous update of %s levels: %04"PRIx16, name, *old);
+        }
     }
     return retval;
 }
 
 static
 bool _sir_updateopts(const char* name, sir_options* old, const sir_options* new) {
-    bool retval = false;
-    if (*old != *new) {
-        _sir_selflog("updating %s options from %08"PRIx32" to %08"PRIx32, name, *old, *new);
-        *old = *new;
-        retval = true;
-    } else {
-        _sir_selflog("skipped superfluous update of %s options: %08"PRIx32, name, *old);
+    bool retval = _sir_validstr(name) && _sir_validptr(old) && _sir_validptr(new);
+    if (retval) {
+        if (*old != *new) {
+            _sir_selflog("updating %s options from %08"PRIx32" to %08"PRIx32, name, *old, *new);
+            *old = *new;
+        } else {
+            _sir_selflog("skipped superfluous update of %s options: %08"PRIx32, name, *old);
+        }
     }
     return retval;
 }
@@ -367,38 +369,44 @@ bool _sir_syslogopts(sirinit* si, const sir_update_config_data* data) {
 }
 
 bool _sir_syslogid(sirinit* si, const sir_update_config_data* data) {
-    bool retval    = false;
-    bool cur_valid = _sir_validstrnofail(si->d_syslog.identity);
-    if (!cur_valid || 0 != strncmp(si->d_syslog.identity, data->sl_identity, SIR_MAX_SYSLOG_ID)) {
-        _sir_selflog("updating %s identity from '%s' to '%s'", SIR_DESTNAME_SYSLOG,
-            si->d_syslog.identity, data->sl_identity);
-        (void)_sir_strncpy(si->d_syslog.identity, SIR_MAX_SYSLOG_ID, data->sl_identity,
-            strnlen(data->sl_identity, SIR_MAX_SYSLOG_ID));
-        _sir_setbitshigh(&si->d_syslog._state.mask, SIRSL_UPDATED | SIRSL_IDENTITY);
-        retval = _sir_syslog_updated(si, data);
-        _sir_setbitslow(&si->d_syslog._state.mask, SIRSL_UPDATED | SIRSL_IDENTITY);
-    } else {
-        _sir_selflog("skipped superfluous update of %s identity: '%s'", SIR_DESTNAME_SYSLOG,
-            si->d_syslog.identity);
+    bool retval = _sir_validptr(si) && _sir_validptr(data);
+
+    if (retval) {
+        bool cur_ok = _sir_validstrnofail(si->d_syslog.identity);
+        if (!cur_ok || 0 != strncmp(si->d_syslog.identity, data->sl_identity, SIR_MAX_SYSLOG_ID)) {
+            _sir_selflog("updating %s identity from '%s' to '%s'", SIR_DESTNAME_SYSLOG,
+                si->d_syslog.identity, data->sl_identity);
+            (void)_sir_strncpy(si->d_syslog.identity, SIR_MAX_SYSLOG_ID, data->sl_identity,
+                strnlen(data->sl_identity, SIR_MAX_SYSLOG_ID));
+            _sir_setbitshigh(&si->d_syslog._state.mask, SIRSL_UPDATED | SIRSL_IDENTITY);
+            retval = _sir_syslog_updated(si, data);
+            _sir_setbitslow(&si->d_syslog._state.mask, SIRSL_UPDATED | SIRSL_IDENTITY);
+        } else {
+            _sir_selflog("skipped superfluous update of %s identity: '%s'", SIR_DESTNAME_SYSLOG,
+                si->d_syslog.identity);
+        }
     }
 
     return retval;
 }
 
 bool _sir_syslogcat(sirinit* si, const sir_update_config_data* data) {
-    bool retval    = false;
-    bool cur_valid = _sir_validstrnofail(si->d_syslog.category);
-    if (!cur_valid || 0 != strncmp(si->d_syslog.category, data->sl_category, SIR_MAX_SYSLOG_CAT)) {
-        _sir_selflog("updating %s category from '%s' to '%s'", SIR_DESTNAME_SYSLOG,
-            si->d_syslog.category, data->sl_category);
-        (void)_sir_strncpy(si->d_syslog.category, SIR_MAX_SYSLOG_CAT, data->sl_category,
-            strnlen(data->sl_category, SIR_MAX_SYSLOG_CAT));
-        _sir_setbitshigh(&si->d_syslog._state.mask, SIRSL_UPDATED | SIRSL_CATEGORY);
-        retval = _sir_syslog_updated(si, data);
-        _sir_setbitslow(&si->d_syslog._state.mask, SIRSL_UPDATED | SIRSL_CATEGORY);
-    } else {
-        _sir_selflog("skipped superfluous update of %s category: '%s'", SIR_DESTNAME_SYSLOG,
-            si->d_syslog.identity);
+    bool retval = _sir_validptr(si) && _sir_validptr(data);
+
+    if (retval) {
+        bool cur_ok = _sir_validstrnofail(si->d_syslog.category);
+        if (!cur_ok || 0 != strncmp(si->d_syslog.category, data->sl_category, SIR_MAX_SYSLOG_CAT)) {
+            _sir_selflog("updating %s category from '%s' to '%s'", SIR_DESTNAME_SYSLOG,
+                si->d_syslog.category, data->sl_category);
+            (void)_sir_strncpy(si->d_syslog.category, SIR_MAX_SYSLOG_CAT, data->sl_category,
+                strnlen(data->sl_category, SIR_MAX_SYSLOG_CAT));
+            _sir_setbitshigh(&si->d_syslog._state.mask, SIRSL_UPDATED | SIRSL_CATEGORY);
+            retval = _sir_syslog_updated(si, data);
+            _sir_setbitslow(&si->d_syslog._state.mask, SIRSL_UPDATED | SIRSL_CATEGORY);
+        } else {
+            _sir_selflog("skipped superfluous update of %s category: '%s'", SIR_DESTNAME_SYSLOG,
+                si->d_syslog.identity);
+        }
     }
 
     return retval;

--- a/src/sirinternal.c
+++ b/src/sirinternal.c
@@ -695,9 +695,9 @@ bool _sir_dispatch(const sirinit* si, sir_level level, sirbuf* buf) {
     size_t wanted     = 0;
 
     if (_sir_bittest(si->d_stdout.levels, level)) {
-        const char* write = _sir_format(true, si->d_stdout.opts, buf);
-        bool wrote        = _sir_validstrnofail(write) &&
-            _sir_write_stdout(write, buf->output_len);
+        const char* writef = _sir_format(true, si->d_stdout.opts, buf);
+        bool wrote         = _sir_validstrnofail(writef) &&
+            _sir_write_stdout(writef, buf->output_len);
         _sir_eqland(retval, wrote);
 
         if (wrote)
@@ -706,9 +706,9 @@ bool _sir_dispatch(const sirinit* si, sir_level level, sirbuf* buf) {
     }
 
     if (_sir_bittest(si->d_stderr.levels, level)) {
-        const char* write = _sir_format(true, si->d_stderr.opts, buf);
-        bool wrote        = _sir_validstrnofail(write) &&
-            _sir_write_stderr(write, buf->output_len);
+        const char* writef = _sir_format(true, si->d_stderr.opts, buf);
+        bool wrote         = _sir_validstrnofail(writef) &&
+            _sir_write_stderr(writef, buf->output_len);
         _sir_eqland(retval, wrote);
 
         if (wrote)

--- a/src/sirplugins.c
+++ b/src/sirplugins.c
@@ -454,7 +454,7 @@ bool _sir_plugin_cache_dispatch(const sir_plugincache* spc, sir_level level, sir
         !_sir_validptr(dispatched) || !_sir_validptr(wanted))
         return false;
 
-    const char* write    = NULL;
+    const char* wrote    = NULL;
     sir_options lastopts = 0;
 
     *dispatched = 0;
@@ -471,13 +471,13 @@ bool _sir_plugin_cache_dispatch(const sir_plugincache* spc, sir_level level, sir
 
         (*wanted)++;
 
-        if (!write || spc->plugins[n]->info.opts != lastopts) {
-            write = _sir_format(false, spc->plugins[n]->info.opts, buf);
-            SIR_ASSERT(write);
+        if (!wrote || spc->plugins[n]->info.opts != lastopts) {
+            wrote = _sir_format(false, spc->plugins[n]->info.opts, buf);
+            SIR_ASSERT(wrote);
             lastopts = spc->plugins[n]->info.opts;
         }
 
-        if (write && spc->plugins[n]->iface.write(level, write)) {
+        if (wrote && spc->plugins[n]->iface.write(level, wrote)) {
             (*dispatched)++;
         } else {
             _sir_selflog("error: write to plugin (path: '%s', id: %08"PRIx32")"

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -1773,11 +1773,9 @@ bool sirtest_filesystem(void) {
         1234
     };
 
-#if defined(__WIN__)
     if (get_wineversion()) {
         bad_fds[3] = 0;
     }
-#endif
 
     for (size_t n = 0; n < _sir_countof(bad_fds); n++) {
         if (_sir_validfd(bad_fds[n])) {

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -348,7 +348,7 @@ bool sirtest_failnooutputdest(void) {
 
 bool sirtest_failnulls(void) {
     INIT_BASE(si, SIRL_ALL, 0, 0, 0, "", false);
-    bool pass = si_init;
+    bool pass = !si_init;
 
     _sir_eqland(pass, !sir_init(NULL));
 
@@ -2493,7 +2493,7 @@ bool roll_and_archive(const char* filename, const char* extension) {
     if (pass) {
         static const char* line = "hello, i am some data. nice to meet you.";
         TEST_MSG("writing to %s until SIR_FROLLSIZE has been exceeded...", logfilename);
-        
+
         /* write an (approximately) known quantity until we should have rolled */
         size_t written  = 0;
         size_t linesize = strnlen(line, SIR_MAXMESSAGE);

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -320,11 +320,10 @@ bool sirtest_failnooutputdest(void) {
     INIT(si, 0, 0, 0, 0);
     bool pass = si_init;
 
-    static const char* logfilename = MAKE_LOG_NAME("nodestination.log");
-
     _sir_eqland(pass, !sir_notice("this goes nowhere!"));
 
     if (pass) {
+        static const char* logfilename = MAKE_LOG_NAME("nodestination.log");
         PRINT_EXPECTED_ERROR();
 
         _sir_eqland(pass, sir_stdoutlevels(SIRL_INFO));
@@ -349,7 +348,7 @@ bool sirtest_failnooutputdest(void) {
 
 bool sirtest_failnulls(void) {
     INIT_BASE(si, SIRL_ALL, 0, 0, 0, "", false);
-    bool pass = true;
+    bool pass = si_init;
 
     _sir_eqland(pass, !sir_init(NULL));
 
@@ -1397,8 +1396,7 @@ bool generic_syslog_test(const char* sl_name, const char* identity, const char* 
         if (set_category)
             (void)_sir_strncpy(si.d_syslog.category, SIR_MAX_SYSLOG_CAT, category, SIR_MAX_SYSLOG_CAT);
 
-        si_init = sir_init(&si); //-V519
-        _sir_eqland(pass, si_init);
+        _sir_eqland(pass, sir_init(&si));
 
         if (do_update)
             _sir_eqland(pass, sir_sysloglevels(SIRL_ALL));
@@ -1775,9 +1773,11 @@ bool sirtest_filesystem(void) {
         1234
     };
 
+#if defined(__WIN__)
     if (get_wineversion()) {
         bad_fds[3] = 0;
     }
+#endif
 
     for (size_t n = 0; n < _sir_countof(bad_fds); n++) {
         if (_sir_validfd(bad_fds[n])) {
@@ -2443,7 +2443,6 @@ bool roll_and_archive(const char* filename, const char* extension) {
     /* roll size minus 1KiB so we can write until it maxes. */
     static const long deltasize = 1024L;
     const long fillsize         = SIR_FROLLSIZE - deltasize;
-    static const char* line     = "hello, i am some data. nice to meet you.";
 
     char logfilename[SIR_MAXPATH] = {0};
     (void)snprintf(logfilename, SIR_MAXPATH, MAKE_LOG_NAME("%s%s"), filename, extension);
@@ -2492,7 +2491,9 @@ bool roll_and_archive(const char* filename, const char* extension) {
     (void)print_test_error(pass, false);
 
     if (pass) {
+        static const char* line = "hello, i am some data. nice to meet you.";
         TEST_MSG("writing to %s until SIR_FROLLSIZE has been exceeded...", logfilename);
+        
         /* write an (approximately) known quantity until we should have rolled */
         size_t written  = 0;
         size_t linesize = strnlen(line, SIR_MAXMESSAGE);

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -348,7 +348,7 @@ bool sirtest_failnooutputdest(void) {
 
 bool sirtest_failnulls(void) {
     INIT_BASE(si, SIRL_ALL, 0, 0, 0, "", false);
-    bool pass = !si_init;
+    bool pass = true;
 
     _sir_eqland(pass, !sir_init(NULL));
 


### PR DESCRIPTION
* Reuse $PATH resolution of binary name from OpenBSD
* Only use fstatat to detect if a file exists when relative to CWD