### PR TITLE
Comment out musl-gcc test due to upstream bug RHBZ#2263904

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -255,7 +255,7 @@ Linux/i686 (G++, GCC):
 
 ################################################################################
 
-Linux/x86_64 (musl-libc, G++, GCC):
+.Linux/x86_64 (musl-libc, G++, GCC):
   stage: build_linux
   needs:
     - job: Style check


### PR DESCRIPTION
* Comment out musl-gcc test due to upstream bug RHBZ#2263904
  * https://bugzilla.redhat.com/show_bug.cgi?id=2263904