### PR TITLE
Add AVX tag to PVS-Studio job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2209,6 +2209,7 @@ PVS-Studio:
   tags:
     - Docker-x64
     - Linux
+    - AVX
   image:
     name: registry.gitlab.com/libsir/libsir/pvs:latest
   script:


### PR DESCRIPTION
* Add AVX tag to PVS-Studio job
  * Older Core 2 runner is failing with latest beta otherwise