### PR TITLE
Indirectly call `memset` when memory is not subsequently accessed in the same scope

### DIFF
--- a/src/sirfilecache.c
+++ b/src/sirfilecache.c
@@ -576,6 +576,7 @@ sirfile* _sir_fcache_find(const sirfcache* sfc, const void* match, sir_fcache_pr
 }
 
 bool _sir_fcache_destroy(sirfcache* sfc) {
+    void*(*const volatile explicit_memset) (void*, int, size_t) = memset;
     bool retval = _sir_validptr(sfc);
 
     if (retval) {
@@ -587,7 +588,7 @@ bool _sir_fcache_destroy(sirfcache* sfc) {
             sfc->count--;
         }
 
-        (void)memset(sfc, 0, sizeof(sirfcache));
+        (void)explicit_memset(sfc, 0, sizeof(sirfcache));
     }
 
     return retval;

--- a/src/sirhelpers.c
+++ b/src/sirhelpers.c
@@ -366,6 +366,8 @@ char* _sir_strsqueeze(char *str) {
 }
 
 char* _sir_strredact(char *str, const char *sub, const char c) {
+    void*(*const volatile explicit_memset) (void*, int, size_t) = memset;
+
     if (!str)
         return NULL;
 
@@ -377,7 +379,7 @@ char* _sir_strredact(char *str, const char *sub, const char c) {
     if (!c || !p)
         return str;
 
-    (void)memset(p, c, strnlen(sub, strlen(str)));
+    (void)explicit_memset(p, c, strnlen(sub, strlen(str)));
 
     return _sir_strredact(str, sub, c);
 }


### PR DESCRIPTION
* Indirectly call `memset` when memory is not subsequently accessed in the same scope