### PR TITLE
Appease latest PVS-Studio 7.29.80616.6568

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ orstlint.txt
 
 # PVS
 compile_commands.json
+compile_commands.events.json
 *.pvs
 pvsreport/*
 *.PVS-Studio.i

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -356,7 +356,7 @@ bool sirtest_failnulls(void) {
         PRINT_EXPECTED_ERROR();
 
     _sir_eqland(pass, sir_init(&si));
-    _sir_eqland(pass, !sir_info(NULL)); //-V618
+    _sir_eqland(pass, !sir_info(NULL)); //-V618 //-V575
 
     if (pass)
         PRINT_EXPECTED_ERROR();


### PR DESCRIPTION
* The NULL pointer test now additionally raises a V575 (*null pointer is passed*) on top of the V618 (*dangerous use of function*), in the `sirtest_failnulls` function in `tests/tests.c`.

  Suppressing this warning, because the test does this intentionally.

* Also, add `compile_commands.events.json` to the `.gitignore` file.