### PR TITLE
Temporarily disable MSBuild tests in Wine; simplify QNX Makefile rules

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4886,7 +4886,7 @@ NetBSD/amd64 (CC, NetBSD Python):
 
 ################################################################################
 
-Windows/x64 (MSVC, MSBuild, Release, C++, C):
+.Windows/x64 (MSVC, MSBuild, Release, C++, C):
   stage: build_windows_msbuild
   needs:
     - job: Style check
@@ -4938,7 +4938,7 @@ Windows/x64 (MSVC, MSBuild, Release, C++, C):
 
 ################################################################################
 
-Windows/x64 (MSVC, MSBuild, Debug, C++, C):
+.Windows/x64 (MSVC, MSBuild, Debug, C++, C):
   stage: build_windows_msbuild
   needs:
     - job: Style check
@@ -4975,7 +4975,7 @@ Windows/x64 (MSVC, MSBuild, Debug, C++, C):
 
 ################################################################################
 
-Windows/x64 (MSVC, MSBuild, Profiling, C++, C):
+.Windows/x64 (MSVC, MSBuild, Profiling, C++, C):
   stage: build_windows_msbuild
   needs:
     - job: Style check
@@ -5012,7 +5012,7 @@ Windows/x64 (MSVC, MSBuild, Profiling, C++, C):
 
 ################################################################################
 
-Windows/Arm64 (MSVC, MSBuild, Release, C++, C):
+.Windows/Arm64 (MSVC, MSBuild, Release, C++, C):
   stage: build_windows_msbuild
   needs:
     - job: Style check
@@ -5049,7 +5049,7 @@ Windows/Arm64 (MSVC, MSBuild, Release, C++, C):
 
 ################################################################################
 
-Windows/Arm64 (MSVC, MSBuild, Debug, C++, C):
+.Windows/Arm64 (MSVC, MSBuild, Debug, C++, C):
   stage: build_windows_msbuild
   needs:
     - job: Style check
@@ -5086,7 +5086,7 @@ Windows/Arm64 (MSVC, MSBuild, Debug, C++, C):
 
 ################################################################################
 
-Windows/Arm64 (MSVC, MSBuild, Profiling, C++, C):
+.Windows/Arm64 (MSVC, MSBuild, Profiling, C++, C):
   stage: build_windows_msbuild
   needs:
     - job: Style check

--- a/sirplatform.mk
+++ b/sirplatform.mk
@@ -227,14 +227,6 @@ ifneq "$(findstring q++,$(CXX))" ""
   QNX?=1
 endif
 
-ifneq "$(findstring nto-qnx,$(CC))" ""
-  QNX?=1
-endif
-
-ifneq "$(findstring nto-qnx,$(CXX))" ""
-  QNX?=1
-endif
-
 ifeq ($(QNX),1)
   LIBDL=
   PTHOPT=


### PR DESCRIPTION
* Temporarily disable MSBuild tests in Wine
* Simplify QNX Makefile rules