### PR TITLE
CI Updates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4421,11 +4421,11 @@ OpenBSD/amd64 (Clang++, Clang):
     - |
       # Start of Build ...
       echo -e "section_start:`date +%s`:Build_section[collapsed=true]\r\e[0K\033[0;36mBuild ...\033[0m" || true
-    - export CC="/usr/local/bin/clang-18"
-    - export CXX="/usr/local/bin/clang++-18"
+    - export CC="/usr/local/bin/clang-19"
+    - export CXX="/usr/local/bin/clang++-19"
     - export CFLAGS="-I/usr/local/include"
     - export CXXFLAGS="-DSIR_NO_STD_FORMAT=1 -I/usr/local/include"
-    - export LDFLAGS="-Wl,-rpath=/usr/local/llvm18/lib/ -L/usr/local/llvm18/lib/ -L/usr/local/lib"
+    - export LDFLAGS="-Wl,-rpath=/usr/local/llvm19/lib/ -L/usr/local/llvm18/lib/ -L/usr/local/lib"
     - uname -a
     - ${CC:?} --version
     - ${CXX:?} --version

--- a/.gitlab-ci/ao64/Dockerfile
+++ b/.gitlab-ci/ao64/Dockerfile
@@ -37,7 +37,7 @@ ARG URL
 
 RUN set -x && \
       wget "${URL:-http://172.17.0.1:8088/x86_open64-4.5.2.1-1.x86_64.rpm}" && \
-      rpm -ivh --nodigest --nofiledigest x86_open64-4.5.2.1-1.x86_64.rpm && \
+      rpm -ivh --nodigest --nofiledigest --nosignature x86_open64-4.5.2.1-1.x86_64.rpm && \
       rm -f x86_open64-4.5.2.1-1.x86_64.rpm && \
       printf '%s\n' 'int matherr=0;' 'char* _LIB_VERSION="";' > tmp.c && \
       gcc -o libmcompat.o -c tmp.c && \

--- a/.gitlab-ci/aocc/Dockerfile
+++ b/.gitlab-ci/aocc/Dockerfile
@@ -37,7 +37,7 @@ ARG URL
 
 RUN set -x && \
       wget "${URL:-https://download.amd.com/developer/eula/aocc/aocc-5-1/aocc-compiler-5.1.0-1.x86_64.rpm}" && \
-      rpm -ivh --nodigest --nofiledigest aocc-compiler-5.1.0-1.x86_64.rpm && \
+      rpm -ivh --nodigest --nofiledigest --nosignature aocc-compiler-5.1.0-1.x86_64.rpm && \
       rm -f aocc-compiler-5.1.0-1.x86_64.rpm && \
       dnf -y clean all && \
       rm -rf ~/.cache > /dev/null 2>&1 && \

--- a/.gitlab-ci/base/Dockerfile
+++ b/.gitlab-ci/base/Dockerfile
@@ -27,7 +27,7 @@
 #
 ################################################################################
 
-FROM quay.io/fedora/fedora:44
+FROM quay.io/fedora/fedora:45
 
 USER 0
 
@@ -69,7 +69,6 @@ RUN set -x && \
       cppcheck \
       cppcheck-htmlreport \
       cppi \
-      croc \
       curl \
       dos2unix \
       doxygen \

--- a/.gitlab-ci/scripts/all.sh
+++ b/.gitlab-ci/scripts/all.sh
@@ -40,9 +40,21 @@ test -f ./scripts/all.sh 2> /dev/null ||
 
 set -eu > /dev/null 2>&1
 
+if [ "${NO_BUILD:-0}" = 1 ]; then
+    BUILD_CMD="true"
+else
+    BUILD_CMD="../scripts/build.sh"
+fi
+
+if [ "${NO_PUSH:-0}" = 1 ]; then
+    PUSH_CMD="true"
+else
+    PUSH_CMD="../scripts/push.sh"
+fi
+
 printf '\n%s\n' "Processing base ..."
 
-(cd base && ../scripts/build.sh && ../scripts/push.sh) ||
+(cd base && "${BUILD_CMD:?}" && "${PUSH_CMD:?}") ||
   {
     printf '%s\n' "ERROR: base processing failed."
     exit 1
@@ -54,7 +66,7 @@ printf '\n%s\n' "Processing all CI images ..."
 
 for dir in $(printf '%s\n' * | grep -Ev '(^base$|^scripts$)' ); do
     printf '\nProcessing %s ...\n' "${dir:?}"
-    (cd "${dir:?}" && ../scripts/build.sh && ../scripts/push.sh) ||
+    (cd "${dir:?}" && ${BUILD_CMD:?} && "${PUSH_CMD:?}") ||
       {
         printf 'ERROR: %s processing failed.\n' "${dir:?}"
         exit 2

--- a/include/sir/platform.h
+++ b/include/sir/platform.h
@@ -513,6 +513,10 @@ _set_thread_local_invalid_parameter_handler(
 #   endif
 #  endif
 
+#  if defined(__PATHCC__) && !defined(__OPEN64__)
+#   define __OPEN64__ __PATHCC__
+#  endif
+
 #  if defined(PATH_MAX)
 #   define SIR_MAXPATH PATH_MAX
 #  elif defined(MAXPATHLEN)


### PR DESCRIPTION
* Use Fedora 45 for container image base.
* Treat the PathScale compiler as we would Open64.
* CI: Allow disabling docker build or push steps when regenerating container images.
* Fix RPM invocation for Fedora 45 and later.
* Update OpenBSD Clang invocation for Clang 19